### PR TITLE
fix(astalify): subclassing

### DIFF
--- a/astal/gtk3/astalify.lua
+++ b/astal/gtk3/astalify.lua
@@ -1,10 +1,29 @@
 local lgi = require('lgi')
-local Astal = lgi.require('Astal', '3.0')
+---@type Gtk
 local Gtk = lgi.require('Gtk', '3.0')
-local GObject = lgi.require('GObject', '2.0')
+---@type GObject
+local GObject = lgi.require('GObject')
+
+---@type Astal
+local Astal = lgi.require('Astal', '3.0')
 local Binding = require('astal.binding')
 local Variable = require('astal.variable')
 local exec_async = require('astal.process').exec_async
+
+local no_implicit_destroy = {}
+
+local function copy(tbl)
+    local new_tbl = {}
+    for key, value in pairs(tbl) do
+        if type(key) == 'number' then
+            table.insert(new_tbl, value)
+        else
+            new_tbl[key] = value
+        end
+    end
+
+    return new_tbl
+end
 
 local function filter(tbl, fn)
     local copy = {}
@@ -21,25 +40,26 @@ local function filter(tbl, fn)
 end
 
 local function map(tbl, fn)
-    local copy = {}
+    local new_tbl = {}
+
     for key, value in pairs(tbl) do
-        copy[key] = fn(value)
+        new_tbl[key] = fn(value)
     end
-    return copy
+    return new_tbl
 end
 
 local function flatten(tbl)
-    local copy = {}
+    local new_tbl = {}
     for _, value in pairs(tbl) do
         if type(value) == 'table' and getmetatable(value) == nil then
             for _, inner in pairs(flatten(value)) do
-                table.insert(copy, inner)
+                table.insert(new_tbl, inner)
             end
         else
-            table.insert(copy, value)
+            table.insert(new_tbl, value)
         end
     end
-    return copy
+    return new_tbl
 end
 
 local function includes(tbl, elem)
@@ -87,17 +107,16 @@ local function set_children(parent, children)
 
     -- TODO: add more container types
     if Astal.Box:is_type_of(parent) then
-        parent:set_children(children)
-    -- elseif Astal.EventBox:is_type_of(parent) then
+        Astal.Box.set_children(parent, children)
     elseif Astal.Stack:is_type_of(parent) then
-        parent:set_children(children)
+        Astal.Stack.set_children(parent, children)
     elseif Astal.CenterBox:is_type_of(parent) then
         parent.start_widget = children[1]
         parent.center_widget = children[2]
         parent.end_widget = children[3]
     elseif Astal.Overlay:is_type_of(parent) then
         parent:set_child(children[1])
-        children[1] = nil
+        table.remove(children, 1)
         parent:set_overlays(children)
     elseif Gtk.Container:is_type_of(parent) then
         for _, child in pairs(children) do
@@ -134,71 +153,142 @@ local function merge_bindings(array)
         return bindings[1]:as(get_values)
     end
 
-    return Variable.derive(bindings, get_values)()
+    return Binding.new(Variable.derive(bindings, get_values))
 end
 
----@alias Connectable GObject.Object | AstalLuaVariable | AstalLuaBinding | any
+---@alias Connectable GObject.Object | { subscribe: fun(callback: function): function }
 
 ---@generic T
----@class astalified<T>: {
+---@class Astalified<T>: {
 ---css: string,
 ---class_name: string,
+---cursor: string,
+---click_through: boolean,
 ---toggle_class_name: fun(self: T, class_name: string, on: boolean),
----hook: fun(self: T, gobject: Connectable, signalOrCallback: string | fun(gobject: Connectable, prop: any), callback?: fun(gobject: Connectable, prop: any))
----}
+---hook: fun(self: T, object: Connectable, signal: string, callback: function) | fun(self: T, object: Connectable, callback: function)}
+local Astalified = {}
 
----@generic W: Gtk.Widget
----@param ctor W
----@return fun(args?: W | astalified<W> |  { setup: fun(self: W | astalified<W>): nil } | table<string, any>): W | astalified<W>
-return function(ctor)
-    function ctor:hook(object, signalOrCallback, callback)
-        if GObject.Object:is_type_of(object) and type(signalOrCallback) == 'string' then
-            local id
-            if string.sub(signalOrCallback, 1, 8) == 'notify::' then
-                local prop = string.gsub(signalOrCallback, 'notify::', '')
-                id = object.on_notify:connect(function()
-                    callback(self, object[prop])
-                end, prop, false)
-            else
-                id = object['on_' .. signalOrCallback]:connect(function(_, ...)
-                    callback(self, ...)
-                end)
-            end
-            self.on_destroy = function()
-                GObject.signal_handler_disconnect(object, id)
-            end
-        elseif type(object.subscribe) == 'function' then
-            local unsub = object.subscribe(function(...)
-                signalOrCallback(self, ...)
-            end)
-            self.on_destroy = unsub
+function Astalified:hook(object, signalOrCallback, callback)
+    if GObject.Object:is_type_of(object) and type(signalOrCallback) == 'string' then
+        local id
+        if string.sub(signalOrCallback, 1, 8) == 'notify::' then
+            local prop = string.gsub(signalOrCallback, 'notify::', '')
+            id = object.on_notify:connect(function()
+                callback(self, object[prop])
+            end, prop, false)
         else
-            error('can not hook: not gobject+signal or subscribable')
+            id = object['on_' .. signalOrCallback]:connect(function(_, ...)
+                callback(self, ...)
+            end)
+        end
+        self.on_destroy = function()
+            GObject.signal_handler_disconnect(object, id)
+        end
+    elseif type(object.subscribe) == 'function' then
+        self.on_destroy = object.subscribe(function(...)
+            signalOrCallback(self, ...)
+        end)
+    else
+        error('can not hook: not gobject+signal or subscribable')
+    end
+end
+
+function Astalified:set_class_name(class_name)
+    local names = {}
+    for word in class_name:gmatch('%S+') do
+        table.insert(names, word)
+    end
+    Astal.widget_set_class_names(self, names) ---@diagnostic disable-line:missing-parameter
+end
+
+function Astalified:get_class_name()
+    local result = ''
+    local strings = Astal.widget_get_class_names(self)
+    for i, str in ipairs(strings) do
+        result = result .. str
+        if i < #strings then
+            result = result .. ' '
         end
     end
+    return result
+end
 
-    function ctor:toggle_class_name(name, on)
-        Astal.widget_toggle_class_name(self, name, on)
+Astalified.toggle_class_name = Astal.widget_toggle_class_name
+
+Astalified.set_css = Astal.widget_set_css
+Astalified.get_css = Astal.widget_get_css
+
+Astalified.set_cursor = Astal.widget_set_cursor
+Astalified.get_cursor = Astal.widget_get_cursor
+
+Astalified.set_click_through = Astal.widget_set_click_through
+Astalified.get_click_through = Astal.widget_get_click_through
+
+return function(ctor)
+    local subclass = ctor:derive('Astalified.' .. ctor._name)
+
+    subclass._attribute = copy(ctor._attribute)
+
+    for key, value in pairs(Astalified) do
+        subclass[key] = value
     end
 
-    return function(tbl)
-        tbl = tbl or {}
+    if subclass.get_children then
+        subclass.set_children = set_children
+        subclass._attribute.children = {
+            set = set_children,
+            get = Gtk.Container.get_children,
+        }
+    end
+
+    subclass._attribute.action_group = {
+        set = function(self, v)
+            self:insert_action_group(v[1], v[2])
+        end,
+    }
+
+    subclass._attribute.no_implicit_destroy = {
+        get = function(self)
+            return no_implicit_destroy[self] or false
+        end,
+        set = function(self, v)
+            if no_implicit_destroy[self] == nil then
+                self.on_destroy = function()
+                    no_implicit_destroy[self] = nil
+                end
+            end
+            no_implicit_destroy[self] = v
+        end,
+    }
+
+    subclass._attribute.css = {
+        get = Astalified.get_css,
+        set = Astalified.set_css,
+    }
+
+    subclass._attribute.class_name = {
+        get = Astalified.get_class_name,
+        set = Astalified.set_class_name,
+    }
+
+    return function(args)
+        args = args or {}
 
         local bindings = {}
-        local setup = tbl.setup
+        local setup = args.setup
 
         -- collect children
-        local children = merge_bindings(flatten(filter(tbl, function(_, key)
+        local children = merge_bindings(flatten(filter(args, function(_, key)
             return type(key) == 'number'
         end)))
 
         -- default visible to true
-        if tbl.visible == nil then
-            tbl.visible = true
+        if args.visible == nil then
+            args.visible = true
         end
 
         -- collect props
-        local props = filter(tbl, function(_, key)
+        local props = filter(args, function(_, key)
             return type(key) == 'string' and key ~= 'setup'
         end)
 
@@ -220,16 +310,16 @@ return function(ctor)
         end
 
         -- construct, attach bindings, add children
-        local widget = ctor()
+        local widget = subclass()
 
         if getmetatable(children) == Binding then
-            set_children(widget, children:get())
+            widget.children = children:get()
             widget.on_destroy = children:subscribe(function(v)
-                set_children(widget, v)
+                widget.children = v
             end)
         else
             if #children > 0 then
-                set_children(widget, children)
+                widget.children = children
             end
         end
 

--- a/astal/gtk3/widget.lua
+++ b/astal/gtk3/widget.lua
@@ -1,12 +1,11 @@
-local lgi = require("lgi")
+local lgi = require('lgi')
 ---@type Astal
-local Astal = lgi.require("Astal", "3.0")
+local Astal = lgi.require('Astal', '3.0')
 ---@type Gtk
-local Gtk = lgi.require("Gtk", "3.0")
-local astalify = require("astal.gtk3.astalify")
+local Gtk = lgi.require('Gtk', '3.0')
+local astalify = require('astal.gtk3.astalify')
 
----@overload fun(ctor: any): function
-local Widget = {
+return {
     astalify = astalify,
     Box = astalify(Astal.Box),
     Button = astalify(Astal.Button),
@@ -30,71 +29,3 @@ local Widget = {
     Switch = astalify(Gtk.Switch),
     Window = astalify(Astal.Window),
 }
-
-Gtk.Widget._attribute.css = {
-    get = Astal.widget_get_css,
-    set = Astal.widget_set_css,
-}
-
-Gtk.Widget._attribute.class_name = {
-    get = function(self)
-        local result = ""
-        local strings = Astal.widget_get_class_names(self)
-        for i, str in ipairs(strings) do
-            result = result .. str
-            if i < #strings then
-                result = result .. " "
-            end
-        end
-        return result
-    end,
-    set = function(self, class_name)
-        local names = {}
-        for word in class_name:gmatch("%S+") do
-            table.insert(names, word)
-        end
-        Astal.widget_set_class_names(self, names)
-    end,
-}
-
-Gtk.Widget._attribute.cursor = {
-    get = Astal.widget_get_cursor,
-    set = Astal.widget_set_cursor,
-}
-
-Gtk.Widget._attribute.click_through = {
-    get = Astal.widget_get_click_through,
-    set = Astal.widget_set_click_through,
-}
-
-Gtk.Widget._attribute.action_group = {
-    set = function(self, v)
-        self:insert_action_group(v[1], v[2])
-    end,
-}
-
-local no_implicit_destroy = {}
-Gtk.Widget._attribute.no_implicit_destroy = {
-    get = function(self)
-        return no_implicit_destroy[self] or false
-    end,
-    set = function(self, v)
-        if no_implicit_destroy[self] == nil then
-            self.on_destroy = function()
-                no_implicit_destroy[self] = nil
-            end
-        end
-        no_implicit_destroy[self] = v
-    end,
-}
-
-Astal.Box._attribute.children = {
-    get = Astal.Box.get_children,
-    set = Astal.Box.set_children,
-}
-
-return setmetatable(Widget, {
-    __call = function(_, ctor)
-        return astalify(ctor)
-    end,
-})


### PR DESCRIPTION
This PR adds a new way to astalify widgets, using subclasses instead of modifying the original class, which resolves inheritance and mixed-attribute conflicts.

Before:

* The `Gtk.Widget` class was modified, which affected all of its corresponding subclasses.
* The `child` attribute of all widgets was modified, causing conflicts with the `child` attribute that lgi provides natively.

Now:

* A subclass is created from the widget provided in the function.
* Properties/methods are added to the new subclass.
* The inherited class has no conflicts and keeps its attributes/methods encapsulated.