### PR TITLE
gtk4, drop astal-io

### DIFF
--- a/astal-dev-1.rockspec
+++ b/astal-dev-1.rockspec
@@ -1,37 +1,38 @@
-package = "astal"
-version = "dev-1"
+---@diagnostic disable:lowercase-global
+package = 'astal'
+version = 'dev-1'
 
 source = {
-    url = "git+https://github.com/tokyob0t/astal-lua",
+    url = 'git+https://github.com/tokyob0t/astal-lua',
 }
 
 description = {
-    summary = "lua bindings for libastal.",
-    homepage = "https://aylur.github.io/astal/",
-    license = "LGPL-2.1",
+    summary = 'lua bindings for libastal.',
+    homepage = 'https://aylur.github.io/astal/',
+    license = 'LGPL-2.1',
 }
 
 dependencies = {
-    "lua >= 5.1, < 5.4",
-    "lgi >= 0.9.2",
+    'lua >= 5.1, < 5.4',
+    'lgi >= 0.9.2',
 }
 
 build = {
-    type = "builtin",
+    type = 'builtin',
     modules = {
-        ["astal.binding"] = "astal/binding.lua",
-        ["astal.file"] = "astal/file.lua",
-        ["astal.init"] = "astal/init.lua",
-        ["astal.process"] = "astal/process.lua",
-        ["astal.time"] = "astal/time.lua",
-        ["astal.variable"] = "astal/variable.lua",
-        ["astal.gtk3.app"] = "astal/gtk3/app.lua",
-        ["astal.gtk3.init"] = "astal/gtk3/init.lua",
-        ["astal.gtk3.astalify"] = "astal/gtk3/astalify.lua",
-        ["astal.gtk3.widget"] = "astal/gtk3/widget.lua",
-        -- ["astal.gtk4.app"] = "astal/gtk4/app.lua",
-        -- ["astal.gtk4.init"] = "astal/gtk4/init.lua",
-        -- ["astal.gtk4.astalify"] = "astal/gtk4/astalify.lua",
-        -- ["astal.gtk4.widget"] = "astal/gtk4/widget.lua",
+        ['astal.binding'] = 'astal/binding.lua',
+        ['astal.file'] = 'astal/file.lua',
+        ['astal.init'] = 'astal/init.lua',
+        ['astal.process'] = 'astal/process.lua',
+        ['astal.time'] = 'astal/time.lua',
+        ['astal.variable'] = 'astal/variable.lua',
+        ['astal.gtk3.app'] = 'astal/gtk3/app.lua',
+        ['astal.gtk3.init'] = 'astal/gtk3/init.lua',
+        ['astal.gtk3.astalify'] = 'astal/gtk3/astalify.lua',
+        ['astal.gtk3.widget'] = 'astal/gtk3/widget.lua',
+        ['astal.gtk4.app'] = 'astal/gtk4/app.lua',
+        ['astal.gtk4.init'] = 'astal/gtk4/init.lua',
+        ['astal.gtk4.astalify'] = 'astal/gtk4/astalify.lua',
+        ['astal.gtk4.widget'] = 'astal/gtk4/widget.lua',
     },
 }

--- a/astal-dev-1.rockspec
+++ b/astal-dev-1.rockspec
@@ -20,19 +20,30 @@ dependencies = {
 build = {
     type = 'builtin',
     modules = {
+        ['astal.init'] = 'astal/init.lua',
         ['astal.binding'] = 'astal/binding.lua',
         ['astal.file'] = 'astal/file.lua',
-        ['astal.init'] = 'astal/init.lua',
         ['astal.process'] = 'astal/process.lua',
         ['astal.time'] = 'astal/time.lua',
         ['astal.variable'] = 'astal/variable.lua',
-        ['astal.gtk3.app'] = 'astal/gtk3/app.lua',
+        ['astal.application'] = 'astal/application.lua',
+        --- Gtk4
         ['astal.gtk3.init'] = 'astal/gtk3/init.lua',
         ['astal.gtk3.astalify'] = 'astal/gtk3/astalify.lua',
         ['astal.gtk3.widget'] = 'astal/gtk3/widget.lua',
-        ['astal.gtk4.app'] = 'astal/gtk4/app.lua',
+        ['astal.gtk3.app'] = 'astal/gtk3/app.lua',
+        --- Gtk4
         ['astal.gtk4.init'] = 'astal/gtk4/init.lua',
         ['astal.gtk4.astalify'] = 'astal/gtk4/astalify.lua',
         ['astal.gtk4.widget'] = 'astal/gtk4/widget.lua',
+        ['astal.gtk4.app'] = 'astal/gtk4/app.lua',
+    },
+    install = {
+        bin = {
+            ['astal-lua'] = 'bin/init.lua',
+        },
+    },
+    build_dependencies = {
+        { 'argparse >= 0.8.1', optional = true },
     },
 }

--- a/astal-dev-1.rockspec
+++ b/astal-dev-1.rockspec
@@ -37,6 +37,8 @@ build = {
         ['astal.gtk4.astalify'] = 'astal/gtk4/astalify.lua',
         ['astal.gtk4.widget'] = 'astal/gtk4/widget.lua',
         ['astal.gtk4.app'] = 'astal/gtk4/app.lua',
+        --- Additional
+        ['astal.requests'] = 'astal/requests.lua',
     },
     install = {
         bin = {

--- a/astal/application.lua
+++ b/astal/application.lua
@@ -1,0 +1,222 @@
+local lgi = require('lgi')
+local Gtk = lgi.require('Gtk')
+local Gio = lgi.require('Gio')
+local GLib = lgi.require('GLib')
+local GObject = lgi.require('GObject')
+
+local DEFAULT_INSTANCE_NAME = 'lua'
+local PATH = '/io/Astal/Application'
+
+local IFACE_INFO = Gio.DBusInterfaceInfo({
+    name = 'io.Astal.Application',
+    methods = {
+        Gio.DBusMethodInfo({ name = 'Quit' }),
+        Gio.DBusMethodInfo({ name = 'Inspector' }),
+        Gio.DBusMethodInfo({
+            name = 'ToggleWindow',
+            in_args = { Gio.DBusArgInfo({ name = 'name', signature = 's' }) },
+        }),
+        Gio.DBusMethodInfo({
+            name = 'Request',
+            in_args = { Gio.DBusArgInfo({ name = 'args', signature = 'as' }) },
+            out_args = { Gio.DBusArgInfo({ name = 'out', signature = 's' }) },
+        }),
+    },
+})
+
+---@class AstalLuaApplicationBase: Gtk.Application
+---@field monitors Gdk.Monitor[]
+local Application = Gtk.Application:derive('AstalLua.ApplicationBase')
+
+Application._attribute.instance_name = {
+    set = function(self, instance_name)
+        self.priv.instance_name = instance_name
+    end,
+    get = function(self)
+        return self.priv.instance_name or DEFAULT_INSTANCE_NAME
+    end,
+}
+
+---@private
+function Application:register_dbus()
+    ---@type Gio.DBusConnection | { register_object: fun(self: Gio.DBusConnection, object_path: string, iface_info: Gio.DBusInterfaceInfo, skibidi_toilet: GObject.Closure ) }
+    local connection = self:get_dbus_connection()
+
+    connection:register_object(
+        PATH,
+        IFACE_INFO,
+        GObject.Closure(function(...)
+            local args = { ... }
+
+            ---@type string, GLib.Variant, Gio.DBusMethodInvocation
+            local method, variant, callback = table.unpack(args, 5, 7)
+
+            if method == 'ToggleWindow' then
+                self:toggle_window(variant[1])
+                return callback:return_value()
+            end
+
+            if method == 'Inspector' then
+                self:inspector()
+                return callback:return_value()
+            end
+
+            if method == 'Quit' then
+                callback:return_value()
+                return self:quit()
+            end
+
+            if method == 'Request' then
+                local request_args = {}
+
+                local array = variant.value[1]
+
+                for _, value in array:ipairs() do
+                    table.insert(request_args, value)
+                end
+
+                if #self.priv.request_handlers == 0 then
+                    return callback:return_value(
+                        GLib.Variant('(s)', { "This app doesn't provide a request handler" })
+                    )
+                end
+
+                for _, fn in ipairs(self.priv.request_handlers) do
+                    fn(request_args, function(r)
+                        callback:return_value(GLib.Variant('(s)', { tostring(r) }))
+                    end)
+                end
+            end
+        end)
+    )
+end
+
+---@param name string
+---@return Gtk.Window?
+function Application:get_window(name)
+    for _, win in ipairs(self:get_windows()) do
+        if win.name == name then
+            return win
+        end
+    end
+end
+
+---@param name string
+function Application:toggle_window(name)
+    local w = assert(self:get_window(name))
+
+    w.visible = not w.visible
+end
+
+function Application:inspector()
+    Gtk.Window.set_interactive_debugging(true)
+end
+
+function Application:apply_css(style, reset)
+    ---@type Gtk.CssProvider
+    local provider = Gtk.CssProvider.new()
+
+    provider.on_parsing_error = function(_, _, error)
+        io.stderr:write(string.format('CSS Error: %s\n', error.message))
+    end
+
+    if reset then
+        self:reset_css()
+    end
+
+    if GLib.file_test(style, 'EXISTS') then
+        provider:load_from_path(style)
+    elseif string.find(style, '^resource://') then
+        style = style:gsub('^resource://', '')
+        provider:load_from_resource(style)
+    else
+        provider:load_from_string(style)
+    end
+
+    self:add_css_provider(provider)
+end
+
+-- function Application:add_css_provider(provider)
+--     error("The method 'add_css_provider' must be overridden in a subclass", 2)
+-- end
+
+-- function Application:remove_css_provider(provider)
+--     error("The method 'remove_css_provider' must be overridden in a subclass", 2)
+-- end
+
+-- function Application:reset_css()
+--     error("The method 'reset_css' must be overridden in a subclass", 2)
+-- end
+
+-- ---@param path string
+-- function Application:add_icons(path)
+--     error("The method 'add_icons' must be overridden in a subclass", 2)
+-- end
+
+---@param fn fun(args: string[], callback: fun(response: string))
+function Application:add_request_handler(fn)
+    table.insert(self.priv.request_handlers, fn)
+end
+
+function Application:_init()
+    self.flags = { 'HANDLES_COMMAND_LINE', 'IS_SERVICE' }
+    self.priv.css_providers = {}
+    self.priv.request_handlers = {}
+end
+
+---@class ApplicationStartArgs
+---@field instance_name? string
+---@field main function
+---@field request_handler? fun(args: string[], response: fun(message: string, ...: string))
+---@field hold? boolean
+---@field icons? string
+---@field icon_theme? string
+---@field cursor_theme? string
+---@field css? string
+
+---@param args ApplicationStartArgs
+function Application:start(args)
+    self.application_id = string.format('io.Astal.%s', args.instance_name or 'lua')
+
+    if type(args.hold) == 'nil' then
+        args.hold = true
+    end
+
+    if args.request_handler then
+        self:add_request_handler(args.request_handler)
+    end
+
+    if args.css then
+        self:apply_css(args.css)
+    end
+
+    if args.icons then
+        self:add_icons(args.icons)
+    end
+
+    self.on_startup = function()
+        if args.main then
+            args.main()
+        end
+
+        self:register()
+        self:register_dbus()
+
+        if args.hold then
+            self:hold()
+        end
+    end
+
+    self:run(arg)
+end
+
+function Application:quit(code)
+    if type(code) ~= 'number' then
+        code = 0
+    end
+
+    Gtk.Application.quit(self)
+    os.exit(code)
+end
+
+return Application

--- a/astal/application.lua
+++ b/astal/application.lua
@@ -24,7 +24,7 @@ local IFACE_INFO = Gio.DBusInterfaceInfo({
     },
 })
 
----@class AstalLuaApplicationBase: Gtk.Application
+---@class AstalLua.ApplicationBase: Gtk.Application
 ---@field monitors Gdk.Monitor[]
 local Application = Gtk.Application:derive('AstalLua.ApplicationBase')
 
@@ -81,8 +81,8 @@ function Application:register_dbus()
                     )
                 end
 
-                for _, fn in ipairs(self.priv.request_handlers) do
-                    fn(request_args, function(r)
+                for i = #self.priv.request_handlers, 1, -1 do
+                    self.priv.request_handlers[i](request_args, function(r)
                         callback:return_value(GLib.Variant('(s)', { tostring(r) }))
                     end)
                 end
@@ -136,22 +136,22 @@ function Application:apply_css(style, reset)
     self:add_css_provider(provider)
 end
 
--- function Application:add_css_provider(provider)
---     error("The method 'add_css_provider' must be overridden in a subclass", 2)
--- end
+function Application:add_css_provider(provider)
+    error("The method 'add_css_provider' must be overridden in a subclass", 2)
+end
 
--- function Application:remove_css_provider(provider)
---     error("The method 'remove_css_provider' must be overridden in a subclass", 2)
--- end
+function Application:remove_css_provider(provider)
+    error("The method 'remove_css_provider' must be overridden in a subclass", 2)
+end
 
--- function Application:reset_css()
---     error("The method 'reset_css' must be overridden in a subclass", 2)
--- end
+function Application:reset_css()
+    error("The method 'reset_css' must be overridden in a subclass", 2)
+end
 
--- ---@param path string
--- function Application:add_icons(path)
---     error("The method 'add_icons' must be overridden in a subclass", 2)
--- end
+---@param path string
+function Application:add_icons(path)
+    error("The method 'add_icons' must be overridden in a subclass", 2)
+end
 
 ---@param fn fun(args: string[], callback: fun(response: string))
 function Application:add_request_handler(fn)
@@ -207,7 +207,7 @@ function Application:start(args)
         end
     end
 
-    self:run(arg)
+    self:quit(self:run({ table.unpack(arg, 0, #arg) }))
 end
 
 function Application:quit(code)

--- a/astal/binding.lua
+++ b/astal/binding.lua
@@ -2,15 +2,22 @@ local lgi = require('lgi')
 local GObject = lgi.require('GObject', '2.0')
 
 ---@class AstalLuaBinding: table
----@field emitter table | GObject.Object
----@field property? string
----@field transform_fn function
+---@field private emitter table | AstalLuaVariable | GObject.Object
+---@field private property? string
+---@field private transform_fn function
 ---@field private __index AstalLuaBinding
----@overload fun(emitter: table | userdata, property?: string): AstalLuaBinding
+---@overload fun(emitter: GObject.Object, property: string): AstalLuaBinding
+---@overload fun(emitter: AstalLuaVariable): AstalLuaBinding
+---@overload fun(emitter: { subscribe: function, get: function }): AstalLuaBinding
 local Binding = {}
 Binding.__index = Binding ---@diagnostic disable-line
+Binding.__type = 'Binding'
 
----@param emitter table | Variable | userdata
+function Binding:is_type_of(object)
+    return type(object) == 'table' and object.__type == self.__type
+end
+
+---@param emitter table | AstalLuaVariable | userdata
 ---@param property? string
 function Binding.new(emitter, property)
     return setmetatable({
@@ -70,6 +77,7 @@ function Binding:subscribe(callback)
     end
 end
 
+---@diagnostic disable-next-line
 return setmetatable(Binding, {
     __call = function(_, emitter, prop)
         return Binding.new(emitter, prop)

--- a/astal/binding.lua
+++ b/astal/binding.lua
@@ -17,8 +17,10 @@ function Binding:is_type_of(object)
     return type(object) == 'table' and object.__type == self.__type
 end
 
----@param emitter table | AstalLuaVariable | userdata
----@param property? string
+---@param emitter GObject.Object
+---@param property string
+---@overload fun(emitter: AstalLuaVariable): AstalLuaBinding
+---@overload fun(emitter: { subscribe: function, get: function }): AstalLuaBinding
 function Binding.new(emitter, property)
     return setmetatable({
         emitter = emitter,

--- a/astal/file.lua
+++ b/astal/file.lua
@@ -1,45 +1,163 @@
-local lgi = require("lgi")
-local Astal = lgi.require("AstalIO", "0.1")
-local GObject = lgi.require("GObject", "2.0")
+local lgi = require('lgi')
+local Gio = lgi.require('Gio')
+---@type GLib
+local GLib = lgi.require('GLib')
 
 local M = {}
 
+---@generic F: function
+---@param fn F
+---@return F
+local async = function(fn)
+    return function(...)
+        return Gio.Async.start(fn)(...)
+    end
+end
+
+---@generic F: function
+---@param fn F
+---@return F
+local await = function(fn)
+    return function(...)
+        return Gio.Async.call(fn)(...)
+    end
+end
+
+---@async
 ---@param path string
----@return string
-function M.read_file(path)
-    return Astal.read_file(path)
+---@return string?
+M.async_read_file = function(path)
+    if not GLib.file_test(path, 'EXISTS') then
+        return
+    end
+
+    local file = Gio.File.new_for_path(path)
+
+    local info = assert(file:async_query_info('standard::size', 'NONE'))
+    local stream = assert(file:async_read())
+
+    local read_buffers = {}
+
+    local remaining = info:get_size()
+
+    while remaining > 0 do
+        local buffer = assert(stream:async_read_bytes(remaining))
+        table.insert(read_buffers, buffer.data)
+        remaining = remaining - #buffer
+    end
+
+    stream:async_close()
+
+    return table.concat(read_buffers)
 end
 
 ---@param path string
----@param callback fun(content: string, err: string): nil
-function M.read_file_async(path, callback)
-    Astal.read_file_async(path, function(_, res)
-        local content, err = Astal.read_file_finish(res)
-        callback(content, err)
-    end)
+---@param callback fun(contents: string?)
+M.read_file_async = async(function(path, callback)
+    callback(M.async_read_file(path))
+end)
+
+---@param path string
+---@return string?
+M.read_file = await(function(path)
+    return M.async_read_file(path)
+end)
+
+---@async
+---@param path string
+---@param contents string
+---@return boolean
+M.async_write_file = function(path, contents)
+    local file = Gio.File.new_for_path(path)
+    local parent = GLib.path_get_dirname(path)
+    local stream
+
+    if not GLib.file_test(parent, 'IS_DIR') then
+        Gio.File.new_for_path(parent):make_directory_with_parents()
+    end
+
+    if GLib.file_test(file:get_path(), 'EXISTS') then
+        stream = file:async_replace(nil, false, 'REPLACE_DESTINATION')
+    else
+        stream = file:async_create('NONE')
+    end
+
+    local pos = 1
+
+    while pos <= #contents do
+        local wrote, err = stream:async_write_bytes(GLib.Bytes(contents:sub(pos)))
+        assert(wrote >= 0, err)
+        pos = pos + wrote
+    end
+
+    return stream:async_close()
 end
 
 ---@param path string
----@param content string
-function M.write_file(path, content)
-    Astal.write_file(path, content)
-end
+---@param contents string
+---@param callback? fun(ok: boolean)
+M.write_file_async = async(function(path, contents, callback)
+    local ok = M.async_write_file(path, contents)
+
+    if callback then
+        callback(ok)
+    end
+end)
 
 ---@param path string
----@param content string
----@param callback? fun(err: string): nil
-function M.write_file_async(path, content, callback)
-    Astal.write_file_async(path, content, function(_, res)
-        if type(callback) == "function" then
-            callback(Astal.write_file_finish(res))
+---@param contents string
+---@return boolean
+M.write_file = await(function(path, contents)
+    return M.async_write_file(path, contents)
+end)
+
+---@param path string
+---@param recursive boolean
+---@param callback fun(file: string, event: Gio.FileMonitorEvent)
+---@overload fun(path: string, callback: fun(file: string, event: Gio.FileMonitorEvent)): Gio.FileMonitor
+M.monitor_file = function(path, recursive, callback)
+    if type(recursive) == 'function' then
+        callback = recursive
+        recursive = false
+    end
+
+    local file = Gio.File.new_for_path(path)
+
+    ---@type Gio.FileMonitor
+    local monitor = file:monitor({ 'WATCH_HARD_LINKS', 'WATCH_MOVES', 'WATCH_MOUNTS' })
+
+    if callback then
+        monitor.on_changed = function(_, _file, _, event_type)
+            callback(_file:get_path(), event_type)
         end
-    end)
-end
+    end
 
----@param path string
----@param callback fun(file: string, event: integer): nil
-function M.monitor_file(path, callback)
-    return Astal.monitor_file(path, GObject.Closure(callback))
+    if recursive and GLib.file_test(file:get_path(), 'IS_DIR') then
+        local enum = file:enumerate_children('standard::*', 'NONE')
+
+        local next_file = function()
+            return enum:next_file()
+        end
+
+        for file_info in next_file do
+            if file_info:get_file_type() == 'DIRECTORY' then
+                local _path = file:get_child(file_info:get_name()):get_path()
+
+                if _path then
+                    local m = M.monitor_file(_path, recursive, callback)
+                    monitor.on_notify.cancelled = function()
+                        m:cancel()
+                    end
+                end
+            end
+        end
+    end
+
+    monitor.on_notify.cancelled = function()
+        monitor:unref()
+    end
+
+    return monitor
 end
 
 return M

--- a/astal/gtk3/app.lua
+++ b/astal/gtk3/app.lua
@@ -1,92 +1,93 @@
-local lgi = require("lgi")
----@type Astal
-local Astal = lgi.require("Astal", "3.0")
----@type AstalIO
-local AstalIO = lgi.require("AstalIO", "0.1")
+local lgi = require('lgi')
+local Gtk = lgi.require('Gtk', '3.0')
+local Gdk = lgi.require('Gdk', '3.0')
+local GLib = lgi.require('GLib')
+local ApplicationBase = require('astal.application')
 
----@class AstalLua: Astal.Application
----@overload fun(): AstalLua
-local AstalLua = Astal.Application:derive("AstalLua")
-local request_handler
+local DISPLAY = Gdk.Display.get_default()
+local SCREEN = Gdk.Screen.get_default()
 
-function AstalLua:do_request(msg, conn)
-    if type(request_handler) == "function" then
-        request_handler(msg, function(response)
-            AstalIO.write_sock(conn, tostring(response), function(_, res)
-                AstalIO.write_sock_finish(res)
-            end)
-        end)
-    else
-        Astal.Application.do_request(self, msg, conn)
+---@class AstalLuaApplicationGtk3: AstalLuaApplicationBase
+local ApplicationGtk3 = ApplicationBase
+
+ApplicationGtk3._attribute.monitors = {
+    get = function()
+        local monitors = {}
+
+        for i = 1, DISPLAY:get_n_monitors() do
+            table.insert(monitors, DISPLAY:get_monitor(i - 1))
+        end
+
+        return monitors
+    end,
+}
+
+function ApplicationGtk3:add_css_provider(provider)
+    Gtk.StyleContext.add_provider_for_screen(SCREEN, provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+
+    table.insert(self.priv.css_providers, provider)
+end
+
+function ApplicationGtk3:remove_css_provider(provider)
+    Gtk.StyleContext.remove_provider_for_screen(SCREEN, provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+
+    for index, prov in ipairs(self.priv.css_providers) do
+        if prov == provider then
+            table.remove(self.priv.css_providers, index)
+        end
     end
 end
 
-function AstalLua:quit(code)
-    Astal.Application.quit(self)
-    os.exit(code)
+function ApplicationGtk3:reset_css()
+    for _, provider in ipairs(self.priv.css_providers) do
+        Gtk.StyleContext.remove_provider_for_screen(SCREEN, provider)
+    end
+
+    self.priv.css_providers = {}
 end
 
----@class StartConfig
----@field icons? string
----@field instance_name? string
----@field gtk_theme? string
----@field icon_theme? string
----@field cursor_theme? string
----@field css? string
----@field hold? boolean
----@field request_handler? fun(msg: string, response: fun(res: any)): nil
----@field main? fun(...): nil
----@field client? fun(message: fun(msg: string): string, ...): nil
+function ApplicationGtk3:add_icons(path)
+    if path and GLib.file_test(path, 'IS_DIR') and GLib.file_test(path, 'EXISTS') then
+        Gtk.IconTheme.get_default():prepend_search_path(path)
+    end
+end
 
----@param config? StartConfig
-function AstalLua:start(config)
-    config = config or {}
+---@param args ApplicationStartArgs
+function ApplicationGtk3:start(args)
+    self.application_id = string.format('io.Astal.%s', args.instance_name or 'lua')
 
-    config.client = config.client
-        or function()
-            print('Astal instance "' .. self.instance_name .. '" is already running')
-            os.exit(1)
+    if type(args.hold) == 'nil' then
+        args.hold = true
+    end
+
+    if args.request_handler then
+        self:add_request_handler(args.request_handler)
+    end
+
+    if args.css then
+        self:apply_css(args.css)
+    end
+
+    if args.icons then
+        self:add_icons(args.icons)
+    end
+
+    self.on_startup = function()
+        if args.main then
+            args.main()
         end
 
-    if config.hold == nil then
-        config.hold = true
-    end
+        self:register()
+        self:register_dbus()
 
-    request_handler = config.request_handler
-
-    if config.css then
-        self:apply_css(config.css)
-    end
-    if config.icons then
-        self:add_icons(config.icons)
-    end
-
-    for _, key in ipairs({ "instance_name", "gtk_theme", "icon_theme", "cursor_theme" }) do
-        if config[key] then
-            self[key] = config[key]
-        end
-    end
-
-    self.on_activate = function()
-        if type(config.main) == "function" then
-            config.main(table.unpack(arg))
-        end
-        if config.hold then
+        if args.hold then
             self:hold()
         end
     end
 
-    local _, err = self:acquire_socket()
-
-    if err ~= nil then
-        return config.client(function(msg)
-            return AstalIO.send_request(self.instance_name, msg)
-        end, table.unpack(arg))
-    end
-
-    self:run(nil)
+    self:run(arg)
 end
 
-local app = AstalLua()
+local app = ApplicationGtk3()
 
 return app

--- a/astal/gtk3/app.lua
+++ b/astal/gtk3/app.lua
@@ -7,7 +7,7 @@ local ApplicationBase = require('astal.application')
 local DISPLAY = Gdk.Display.get_default()
 local SCREEN = Gdk.Screen.get_default()
 
----@class AstalLuaApplicationGtk3: AstalLuaApplicationBase
+---@class AstalLua.ApplicationGtk3: AstalLua.ApplicationBase
 local ApplicationGtk3 = ApplicationBase
 
 ApplicationGtk3._attribute.monitors = {
@@ -88,6 +88,7 @@ function ApplicationGtk3:start(args)
     self:run(arg)
 end
 
+---@type AstalLua.ApplicationGtk3
 local app = ApplicationGtk3()
 
 return app

--- a/astal/gtk3/astalify.lua
+++ b/astal/gtk3/astalify.lua
@@ -137,19 +137,15 @@ local function merge_bindings(array)
     return Variable.derive(bindings, get_values)()
 end
 
----@alias Connectable GObject.Object | AstalLuaVariable | AstalLuaBinding | any
-
----@generic T
----@class astalified<T>: {
----css: string,
----class_name: string,
----toggle_class_name: fun(self: T, class_name: string, on: boolean),
----hook: fun(self: T, gobject: Connectable, signalOrCallback: string | fun(gobject: Connectable, prop: any), callback?: fun(gobject: Connectable, prop: any))
----}
+---@class Astalified3: Gtk.Widget
+---@field css string
+---@field class_name string
+---@field toggle_class_name string
+---@field hook fun(self: Gtk.Widget, gobject: Connectable, signalOrCallback: string | fun(gobject: Connectable, prop: any), callback?: fun(gobject: Connectable, prop: any) )
 
 ---@generic W: Gtk.Widget
 ---@param ctor W
----@return fun(args?: W | astalified<W> |  { setup: fun(self: W | astalified<W>): nil } | table<string, any>): W | astalified<W>
+---@return fun(args?: W | Astalified3 |  { setup: fun(self: W | Astalified3): nil } | table<string, any>): W | Astalified3
 return function(ctor)
     function ctor:hook(object, signalOrCallback, callback)
         if GObject.Object:is_type_of(object) and type(signalOrCallback) == 'string' then
@@ -222,7 +218,7 @@ return function(ctor)
         -- construct, attach bindings, add children
         local widget = ctor()
 
-        if getmetatable(children) == Binding then
+        if Binding:is_type_of(children) then
             set_children(widget, children:get())
             widget.on_destroy = children:subscribe(function(v)
                 set_children(widget, v)

--- a/astal/gtk3/init.lua
+++ b/astal/gtk3/init.lua
@@ -1,7 +1,6 @@
 local lgi = require("lgi")
 
 return {
-    App = require("astal.gtk3.app"),
     astalify = require("astal.gtk3.astalify"),
     Widget = require("astal.gtk3.widget"),
 

--- a/astal/gtk4/app.lua
+++ b/astal/gtk4/app.lua
@@ -6,7 +6,7 @@ local ApplicationBase = require('astal.application')
 
 local DISPLAY = Gdk.Display.get_default()
 
----@class AstalLuaApplicationGtk4: AstalLuaApplicationBase,Gtk.Application
+---@class AstalLua.ApplicationGtk4: AstalLua.ApplicationBase
 local ApplicationGtk4 = ApplicationBase
 
 ApplicationGtk4._attribute.monitors = {
@@ -56,6 +56,7 @@ function ApplicationGtk4:add_icons(path)
     end
 end
 
+---@type AstalLua.ApplicationGtk4
 local app = ApplicationGtk4()
 
 return app

--- a/astal/gtk4/app.lua
+++ b/astal/gtk4/app.lua
@@ -1,0 +1,92 @@
+local lgi = require('lgi')
+---@type Astal
+local Astal = lgi.require('Astal', '4.0')
+---@type AstalIO
+local AstalIO = lgi.require('AstalIO', '0.1')
+
+---@class Application: Astal.Application
+---@overload fun(): Application
+local Application = Astal.Application:derive('AstalLuaApplication')
+local request_handler
+
+function Application:do_request(msg, conn)
+    if type(request_handler) == 'function' then
+        request_handler(msg, function(response)
+            AstalIO.write_sock(conn, tostring(response), function(_, res)
+                AstalIO.write_sock_finish(res)
+            end)
+        end)
+    else
+        Astal.Application.do_request(self, msg, conn)
+    end
+end
+
+function Application:quit(code)
+    Astal.Application.quit(self)
+    os.exit(code)
+end
+
+---@class StartConfig
+---@field icons? string
+---@field instance_name? string
+---@field gtk_theme? string
+---@field icon_theme? string
+---@field cursor_theme? string
+---@field css? string
+---@field hold? boolean
+---@field request_handler? fun(msg: string, response: fun(res: any)): nil
+---@field main? fun(...): nil
+---@field client? fun(message: fun(msg: string): string, ...): nil
+
+---@param config? StartConfig
+function Application:start(config)
+    config = config or {}
+
+    config.client = config.client
+        or function()
+            print('Astal instance "' .. self.instance_name .. '" is already running')
+            os.exit(1)
+        end
+
+    if config.hold == nil then
+        config.hold = true
+    end
+
+    request_handler = config.request_handler
+
+    if config.css then
+        self:apply_css(config.css)
+    end
+    if config.icons then
+        self:add_icons(config.icons)
+    end
+
+    for _, key in ipairs({ 'instance_name', 'gtk_theme', 'icon_theme', 'cursor_theme' }) do
+        if config[key] then
+            self[key] = config[key]
+        end
+    end
+
+    self.on_activate = function()
+        if type(config.main) == 'function' then
+            config.main(table.unpack(arg))
+        end
+        if config.hold then
+            self:hold()
+        end
+    end
+
+    local _, err = self:acquire_socket()
+
+    if err ~= nil then
+        return config.client(function(msg)
+            return AstalIO.send_request(self.instance_name, msg)
+        end, table.unpack(arg))
+    end
+
+    self:run(nil)
+end
+
+local app = Application()
+
+return app

--- a/astal/gtk4/astalify.lua
+++ b/astal/gtk4/astalify.lua
@@ -85,6 +85,23 @@ local function merge_bindings(array)
     return bind(Variable.derive(bindings, get_values))
 end
 
+local function ensure_widgets(children)
+    return map(
+        filter(flatten(children), function(item)
+            return not not item
+        end),
+        function(item)
+            if Gtk.Widget:is_type_of(item) then
+                return item
+            end
+            return Gtk.Label({
+                visible = true,
+                label = tostring(item),
+            })
+        end
+    )
+end
+
 ---@class EventController
 ---@field on_focus_enter fun(self: Gtk.Widget)
 ---@field on_focus_leave fun(self: Gtk.Widget)
@@ -247,21 +264,6 @@ function Astalified4:hook(object, signalOrCallback, callback)
 end
 
 function Astalified4:set_children(children)
-    children = map(
-        filter(flatten(children), function(item)
-            return not not item
-        end),
-        function(item)
-            if Gtk.Widget:is_type_of(item) then
-                return item
-            end
-            return Gtk.Label({
-                visible = true,
-                label = tostring(item),
-            })
-        end
-    )
-
     for _, child in ipairs(children) do
         self:do_add_child(dummy_builder, child)
     end
@@ -321,7 +323,7 @@ return function(ctor, config)
             end
         end
 
-        set(self, children)
+        set(self, ensure_widgets(children))
     end
 
     ctor.get_children = function(self)

--- a/astal/gtk4/astalify.lua
+++ b/astal/gtk4/astalify.lua
@@ -1,0 +1,441 @@
+local lgi = require('lgi')
+---@type Gtk
+local Gtk = lgi.require('Gtk', '4.0')
+---@type GObject
+local GObject = lgi.require('GObject')
+
+---@type Gdk
+local Gdk = lgi.require('Gdk')
+
+local Variable = require('astal.variable')
+local bind = require('astal.binding')
+local dummy_builder = Gtk.Builder.new()
+
+local function filter(tbl, fn)
+    local copy = {}
+    for key, value in pairs(tbl) do
+        if fn(value, key) then
+            if type(key) == 'number' then
+                table.insert(copy, value)
+            else
+                copy[key] = value
+            end
+        end
+    end
+    return copy
+end
+
+local function map(tbl, fn)
+    local copy = {}
+    for key, value in pairs(tbl) do
+        copy[key] = fn(value)
+    end
+    return copy
+end
+
+local function flatten(tbl)
+    local copy = {}
+    for _, value in pairs(tbl) do
+        if type(value) == 'table' and getmetatable(value) == nil then
+            for _, inner in pairs(flatten(value)) do
+                table.insert(copy, inner)
+            end
+        else
+            table.insert(copy, value)
+        end
+    end
+    return copy
+end
+
+local function includes(tbl, elem)
+    for _, value in pairs(tbl) do
+        if value == elem then
+            return true
+        end
+    end
+    return false
+end
+
+local function merge_bindings(array)
+    local function get_values(...)
+        local args = { ... }
+        local i = 0
+        return map(array, function(value)
+            if bind:is_type_of(value) then
+                i = i + 1
+                return args[i]
+            else
+                return value
+            end
+        end)
+    end
+
+    local bindings = filter(array, function(v)
+        return bind:is_type_of(v)
+    end)
+
+    if #bindings == 0 then
+        return array
+    end
+
+    if #bindings == 1 then
+        return bindings[1]:as(get_values)
+    end
+
+    return bind(Variable.derive(bindings, get_values))
+end
+
+---@alias Connectable GObject.Object | AstalLuaVariable | { subscribe: function }
+
+---@alias EventControllerKey fun(self: Gtk.Widget, keyval: number, keycode: number, state: Gdk.ModifierType)
+---@alias EventControllerButton fun(self: Gtk.Widget, button: number, n_press: number, x: number, y: number )
+
+---@alias EventController {
+---on_focus_enter: fun(self: Gtk.Widget),
+---on_focus_leave: fun(self: Gtk.Widget),
+---on_key_pressed: EventControllerKey,
+---on_key_released: EventControllerKey,
+---on_key_modifier: fun(self: Gtk.Widget, state: Gdk.ModifierType),
+---on_hover_enter: fun(self: Gtk.Widget, x: number, y: number),
+---on_hover_leave: fun(self: Gtk.Widget),
+---on_motion: fun(self: Gtk.Widget, x: number, y: number),
+---on_scroll: fun(self: Gtk.Widget, dx: number, dy: number),
+---on_scroll_decelerate: fun(self: Gtk.Widget, velocity_x: number, velocity_y: number),
+---on_button_pressed: EventControllerButton,
+---on_button_released: EventControllerButton,
+---on_drag_begin: fun(self: Gtk.Widget, start_x: number, start_y: number),
+---on_drag_update: fun(self: Gtk.Widget, offset_x: number, offset_y: number),
+---on_drag_end: fun(self: Gtk.Widget, offset_x: number, offset_y: number),
+---}
+
+---@param widget Gtk.Widget | Astalified4
+---@param args EventController
+local function setup_controllers(widget, args)
+    local function pick(...)
+        local tbl = {}
+        for _, value in ipairs({ ... }) do
+            if args[value] then
+                table.insert(tbl, args[value])
+                args[value] = nil
+            else
+                table.insert(tbl, false)
+            end
+        end
+        return table.unpack(tbl)
+    end
+
+    local function attach(controller, signals)
+        widget:add_controller(controller)
+        for signal, handler in pairs(signals) do
+            if handler then
+                widget:hook(controller, signal, function(_, ...)
+                    handler(widget, ...)
+                end)
+            end
+        end
+    end
+
+    -- Focus
+    local on_focus_enter, on_focus_leave = pick('on_focus_enter', 'on_focus_leave')
+
+    if on_focus_enter or on_focus_leave then
+        attach(Gtk.EventControllerFocus.new(), {
+            enter = on_focus_enter,
+            leave = on_focus_leave,
+        })
+    end
+
+    -- Keys
+    local on_key_pressed, on_key_released, on_key_modifier =
+        pick('on_key_pressed', 'on_key_released', 'on_key_modifier')
+
+    if on_key_pressed or on_key_released or on_key_modifier then
+        attach(Gtk.EventControllerKey.new(), {
+            ['key-pressed'] = on_key_pressed,
+            ['key-released'] = on_key_released,
+            modifiers = on_key_modifier,
+        })
+    end
+
+    -- Legacy mouse / generic events
+    local on_button_pressed, on_button_released = pick('on_button_pressed', 'on_button_released')
+
+    if on_button_pressed or on_button_released then
+        local primary, middle, secondary =
+            Gtk.GestureClick({ button = Gdk.BUTTON_PRIMARY }),
+            Gtk.GestureClick({ button = Gdk.BUTTON_MIDDLE }),
+            Gtk.GestureClick({ button = Gdk.BUTTON_SECONDARY })
+
+        for _, controller in ipairs({ primary, middle, secondary }) do
+            widget:add_controller(controller)
+            if on_button_pressed then
+                widget:hook(controller, 'pressed', function(_, ...)
+                    on_button_pressed(widget, controller.button, ...)
+                end)
+            end
+
+            if on_button_released then
+                widget:hook(controller, 'released', function(_, ...)
+                    on_button_released(widget, controller.button, ...)
+                end)
+            end
+        end
+    end
+
+    -- Hover / Motion
+    local on_hover_enter, on_hover_leave, on_motion =
+        pick('on_hover_enter', 'on_hover_leave', 'on_motion')
+
+    if on_hover_enter or on_hover_leave or on_motion then
+        attach(Gtk.EventControllerMotion.new(), {
+            enter = on_hover_enter,
+            leave = on_hover_leave,
+            motion = on_motion,
+        })
+    end
+
+    -- Scroll
+    local on_scroll, on_scroll_decelerate = pick('on_scroll', 'on_scroll_decelerate')
+
+    if on_scroll or on_scroll_decelerate then
+        attach(Gtk.EventControllerScroll.new({ 'BOTH_AXES', 'KINETIC' }), {
+            scroll = on_scroll,
+            decelerate = on_scroll_decelerate,
+        })
+    end
+
+    local on_drag_begin, on_drag_update, on_drag_end =
+        pick('on_drag_begin', 'on_drag_update', 'on_drag_end')
+
+    if on_drag_begin or on_drag_update or on_drag_end then
+        attach(Gtk.GestureDrag.new(), {
+            ['drag-begin'] = on_drag_begin,
+            ['drag-update'] = on_drag_update,
+            ['drag-end'] = on_drag_end,
+        })
+    end
+
+    return args
+end
+
+---@class Astalified4: Gtk.Widget
+---@field children Gtk.Widget[]
+---@field no_implicit_destroy boolean
+---@field hook fun(self, object: Connectable, signal: string, callback: function) | fun(self, object: Connectable, callback: function)
+---@field get_child? fun(self): Gtk.Widget
+---@field get_first_child? fun(self): Gtk.Widget
+local Astalified4 = {}
+
+function Astalified4:hook(object, signalOrCallback, callback)
+    if GObject.Object:is_type_of(object) and type(signalOrCallback) == 'string' then
+        local id
+        if string.sub(signalOrCallback, 1, 8) == 'notify::' then
+            local prop = string.gsub(signalOrCallback, 'notify::', '')
+            id = object.on_notify:connect(function()
+                callback(self, object[prop])
+            end, prop, false)
+        else
+            id = object['on_' .. signalOrCallback]:connect(function(_, ...)
+                callback(self, ...)
+            end)
+        end
+        self.on_destroy = function()
+            GObject.signal_handler_disconnect(object, id)
+        end
+    elseif type(object.subscribe) == 'function' then
+        self.on_destroy = object:subscribe(function(...)
+            signalOrCallback(self, ...)
+        end)
+    else
+        error('can not hook: not gobject+signal or subscribable')
+    end
+end
+
+function Astalified4:set_children(children)
+    children = map(
+        filter(flatten(children), function(item)
+            return not not item
+        end),
+        function(item)
+            if Gtk.Widget:is_type_of(item) then
+                return item
+            end
+            return Gtk.Label({
+                visible = true,
+                label = tostring(item),
+            })
+        end
+    )
+
+    for _, child in ipairs(children) do
+        self:do_add_child(dummy_builder, child)
+    end
+end
+
+function Astalified4:get_children()
+    local ok = pcall(function()
+        return self.get_child ~= nil
+    end)
+
+    if ok then
+        return { self:get_child() }
+    end
+
+    local children = {}
+    local ch = self:get_first_child()
+
+    while ch do
+        table.insert(children, ch)
+        ch = ch:get_next_sibling()
+    end
+
+    return children
+end
+
+local set_children = {}
+local get_children = {}
+local no_implicit_destroy = {}
+
+---@alias ConstructorProps Astalified4 | EventController | table<any, any>
+
+---@generic T: Gtk.Widget
+---@param ctor T
+---@param config? { set_children?: fun(self: T, children: Gtk.Widget[]), get_children?: fun(self: T): Gtk.Widget[] }
+---@return fun(args?: T | ConstructorProps | { setup: fun(self: T | Astalified4) }): T | Astalified4
+return function(ctor, config)
+    if not config then
+        config = {}
+    end
+
+    ctor.hook = Astalified4.hook ---@diagnostic disable-line:inject-field
+
+    local set, get =
+        config.set_children or Astalified4.set_children,
+        config.get_children or Astalified4.get_children
+
+    get_children[ctor._name] = get
+
+    set_children[ctor._name] = function(self, children)
+        for _, child in ipairs(get(self)) do
+            if Gtk.Widget:is_type_of(child) then
+                child:unparent()
+
+                if not includes(children, child) and not child.no_implicit_destroy then
+                    child:run_dispose()
+                end
+            end
+        end
+
+        set(self, children)
+    end
+
+    -- ctor.get_children = function(self)
+    --     return self.children
+    -- end
+
+    -- ctor.set_children = function(self, children)
+    --     self.children = children
+    -- end
+
+    ---@diagnostic disable-next-line:undefined-field
+    ctor._attribute.children = {
+        set = function(self, children)
+            local setter = set_children[self._name]
+            setter(self, children)
+        end,
+        get = function(self)
+            local getter = get_children[self._name]
+            return getter(self)
+        end,
+    }
+
+    ---@diagnostic disable-next-line:undefined-field
+    ctor._attribute.no_implicit_destroy = {
+        get = function(self)
+            return no_implicit_destroy[self] or false
+        end,
+        set = function(self, v)
+            if no_implicit_destroy[self] == nil then
+                self.on_destroy = function()
+                    no_implicit_destroy[self] = nil
+                end
+            end
+            no_implicit_destroy[self] = v
+        end,
+    }
+
+    return function(args)
+        local bindings = {}
+        local signal_handlers = {}
+        local setup = args.setup
+
+        if type(args.visible) == 'nil' then
+            args.visible = true
+        end
+
+        args.setup = nil
+
+        local children = merge_bindings(flatten(filter(args, function(_, key)
+            return type(key) == 'number'
+        end)))
+
+        local props = filter(args, function(_, key)
+            return type(key) == 'string'
+        end)
+
+        for key, value in pairs(props) do
+            if string.sub(key, 1, 3) == 'on_' and type(value) == 'function' then
+                signal_handlers[key] = value
+                props[key] = nil
+            end
+        end
+
+        for key, value in pairs(props) do
+            if bind:is_type_of(value) then
+                bindings[key] = value
+                props[key] = value:get()
+            end
+        end
+
+        local new = ctor()
+
+        setup_controllers(new, signal_handlers)
+
+        if bind:is_type_of(children) then
+            new.children = children:get()
+            new.on_destroy = children:subscribe(function(value)
+                new.children = value
+            end)
+        elseif #children > 0 then
+            new.children = children
+        end
+
+        for prop, binding in pairs(bindings) do
+            new.on_destroy = binding:subscribe(function(v)
+                new[prop] = v
+            end)
+        end
+
+        for signal, callback in pairs(signal_handlers) do
+            signal = signal:sub(4)
+
+            if string.sub(signal, 1, 7) == 'notify_' then
+                signal = 'notify::' .. string.sub(signal, 8)
+            end
+
+            signal = signal:gsub('_', '-')
+
+            new:hook(new, signal, callback)
+        end
+
+        for prop, value in pairs(props) do
+            new[prop] = value
+        end
+
+        if setup then
+            setup(new)
+        end
+
+        return new
+    end
+end

--- a/astal/gtk4/astalify.lua
+++ b/astal/gtk4/astalify.lua
@@ -85,8 +85,6 @@ local function merge_bindings(array)
     return bind(Variable.derive(bindings, get_values))
 end
 
----@alias Connectable GObject.Object | AstalLuaVariable | { subscribe: function }
-
 ---@alias EventControllerKey fun(self: Gtk.Widget, keyval: number, keycode: number, state: Gdk.ModifierType)
 ---@alias EventControllerButton fun(self: Gtk.Widget, button: number, n_press: number, x: number, y: number )
 
@@ -129,7 +127,7 @@ local function setup_controllers(widget, args)
         for signal, handler in pairs(signals) do
             if handler then
                 widget:hook(controller, signal, function(_, ...)
-                    handler(widget, ...)
+                    return handler(widget, ...)
                 end)
             end
         end
@@ -170,13 +168,13 @@ local function setup_controllers(widget, args)
             widget:add_controller(controller)
             if on_button_pressed then
                 widget:hook(controller, 'pressed', function(_, ...)
-                    on_button_pressed(widget, controller.button, ...)
+                    return on_button_pressed(widget, controller.button, ...)
                 end)
             end
 
             if on_button_released then
                 widget:hook(controller, 'released', function(_, ...)
-                    on_button_released(widget, controller.button, ...)
+                    return on_button_released(widget, controller.button, ...)
                 end)
             end
         end
@@ -329,23 +327,21 @@ return function(ctor, config)
         set(self, children)
     end
 
-    -- ctor.get_children = function(self)
-    --     return self.children
-    -- end
+    ctor.get_children = function(self)
+        return self.children
+    end
 
-    -- ctor.set_children = function(self, children)
-    --     self.children = children
-    -- end
+    ctor.set_children = function(self, children)
+        self.children = children
+    end
 
     ---@diagnostic disable-next-line:undefined-field
     ctor._attribute.children = {
         set = function(self, children)
-            local setter = set_children[self._name]
-            setter(self, children)
+            set_children[self._name](self, children)
         end,
         get = function(self)
-            local getter = get_children[self._name]
-            return getter(self)
+            return get_children[self._name](self)
         end,
     }
 

--- a/astal/gtk4/astalify.lua
+++ b/astal/gtk4/astalify.lua
@@ -85,26 +85,22 @@ local function merge_bindings(array)
     return bind(Variable.derive(bindings, get_values))
 end
 
----@alias EventControllerKey fun(self: Gtk.Widget, keyval: number, keycode: number, state: Gdk.ModifierType)
----@alias EventControllerButton fun(self: Gtk.Widget, button: number, n_press: number, x: number, y: number )
-
----@alias EventController {
----on_focus_enter: fun(self: Gtk.Widget),
----on_focus_leave: fun(self: Gtk.Widget),
----on_key_pressed: EventControllerKey,
----on_key_released: EventControllerKey,
----on_key_modifier: fun(self: Gtk.Widget, state: Gdk.ModifierType),
----on_hover_enter: fun(self: Gtk.Widget, x: number, y: number),
----on_hover_leave: fun(self: Gtk.Widget),
----on_motion: fun(self: Gtk.Widget, x: number, y: number),
----on_scroll: fun(self: Gtk.Widget, dx: number, dy: number),
----on_scroll_decelerate: fun(self: Gtk.Widget, velocity_x: number, velocity_y: number),
----on_button_pressed: EventControllerButton,
----on_button_released: EventControllerButton,
----on_drag_begin: fun(self: Gtk.Widget, start_x: number, start_y: number),
----on_drag_update: fun(self: Gtk.Widget, offset_x: number, offset_y: number),
----on_drag_end: fun(self: Gtk.Widget, offset_x: number, offset_y: number),
----}
+---@class EventController
+---@field on_focus_enter fun(self: Gtk.Widget)
+---@field on_focus_leave fun(self: Gtk.Widget)
+---@field on_key_pressed fun(self: Gtk.Widget, keyval: number, keycode: number, state: Gdk.ModifierType)
+---@field on_key_released fun(self: Gtk.Widget, keyval: number, keycode: number, state: Gdk.ModifierType)
+---@field on_key_modifier fun(self: Gtk.Widget, state: Gdk.ModifierType)
+---@field on_hover_enter fun(self: Gtk.Widget, x: number, y: number)
+---@field on_hover_leave fun(self: Gtk.Widget)
+---@field on_motion fun(self: Gtk.Widget, x: number, y: number)
+---@field on_scroll fun(self: Gtk.Widget, dx: number, dy: number)
+---@field on_scroll_decelerate fun(self: Gtk.Widget, velocity_x: number, velocity_y: number)
+---@field on_button_pressed fun(self: Gtk.Widget, button: number, n_press: number, x: number, y: number )
+---@field on_button_released fun(self: Gtk.Widget, button: number, n_press: number, x: number, y: number )
+---@field on_drag_begin fun(self: Gtk.Widget, start_x: number, start_y: number)
+---@field on_drag_update fun(self: Gtk.Widget, offset_x: number, offset_y: number)
+---@field on_drag_end fun(self: Gtk.Widget, offset_x: number, offset_y: number)
 
 ---@param widget Gtk.Widget | Astalified4
 ---@param args EventController
@@ -166,6 +162,7 @@ local function setup_controllers(widget, args)
 
         for _, controller in ipairs({ primary, middle, secondary }) do
             widget:add_controller(controller)
+
             if on_button_pressed then
                 widget:hook(controller, 'pressed', function(_, ...)
                     return on_button_pressed(widget, controller.button, ...)

--- a/astal/gtk4/init.lua
+++ b/astal/gtk4/init.lua
@@ -1,7 +1,6 @@
 local lgi = require('lgi')
 
 return {
-    -- App = require('astal.gtk4.app'),
     astalify = require('astal.gtk4.astalify'),
     Widget = require('astal.gtk4.widget'),
 

--- a/astal/gtk4/init.lua
+++ b/astal/gtk4/init.lua
@@ -1,0 +1,11 @@
+local lgi = require('lgi')
+
+return {
+    -- App = require('astal.gtk4.app'),
+    astalify = require('astal.gtk4.astalify'),
+    Widget = require('astal.gtk4.widget'),
+
+    Gtk = lgi.require('Gtk', '4.0'),
+    Gdk = lgi.require('Gdk', '4.0'),
+    Astal = lgi.require('Astal', '4.0'),
+}

--- a/astal/gtk4/widget.lua
+++ b/astal/gtk4/widget.lua
@@ -1,0 +1,180 @@
+local lgi = require('lgi')
+---@type Gtk
+local Gtk = lgi.require('Gtk', '4.0')
+---@type Astal
+local Astal = lgi.require('Astal', '4.0')
+
+local astalify = require('astal.gtk4.astalify')
+
+---@diagnostic disable-next-line
+Gtk.Widget._attribute.action_group = {
+    set = function(self, ag)
+        self:insert_action_group(ag[1], ag[2])
+    end,
+}
+
+---@type Gtk.Box | { vertical: boolean }
+local Box = Gtk.Box
+
+---@diagnostic disable-next-line
+Box._attribute.vertical = {
+    get = function(self)
+        return self.orientation == 'VERTICAL'
+    end,
+    set = function(self, vertical)
+        self.orientation = vertical and 'VERTICAL' or 'HORIZONTAL'
+    end,
+}
+
+---@type Astal.Slider | { format_value_function: (fun(self: Astal.Slider, value: number): string) }
+local Slider = Astal.Slider
+
+---@diagnostic disable-next-line
+Slider._attribute.format_value_func = {
+    set = function(self, fn)
+        self:set_format_value_func(fn)
+    end,
+}
+
+---@type Gtk.DrawingArea | { draw_func: fun(self: Gtk.DrawingArea, cr: cairo.Context, width: integer, height: integer) }
+local DrawingArea = Gtk.DrawingArea
+
+---@diagnostic disable-next-line
+DrawingArea._attribute.draw_func = {
+    set = function(self, fn)
+        self:set_draw_func(fn)
+    end,
+}
+
+---@param children any[]
+---@return ( Gtk.Widget | Gtk.Label )[]
+local filter = function(children)
+    local function filter(tbl, fn)
+        local copy = {}
+        for key, value in pairs(tbl) do
+            if fn(value, key) then
+                if type(key) == 'number' then
+                    table.insert(copy, value)
+                else
+                    copy[key] = value
+                end
+            end
+        end
+        return copy
+    end
+
+    local function map(tbl, fn)
+        local copy = {}
+        for key, value in pairs(tbl) do
+            copy[key] = fn(value)
+        end
+        return copy
+    end
+
+    local function flatten(tbl)
+        local copy = {}
+        for _, value in pairs(tbl) do
+            if type(value) == 'table' and getmetatable(value) == nil then
+                for _, inner in pairs(flatten(value)) do
+                    table.insert(copy, inner)
+                end
+            else
+                table.insert(copy, value)
+            end
+        end
+        return copy
+    end
+
+    return map(
+        filter(flatten(children), function(item)
+            return not not item
+        end),
+        function(item)
+            if Gtk.Widget:is_type_of(item) then
+                return item
+            end
+            return Gtk.Label({
+                visible = true,
+                label = tostring(item),
+            })
+        end
+    )
+end
+
+return {
+    __filter = filter,
+    astalify = astalify,
+
+    DrawingArea = astalify(DrawingArea),
+
+    Window = astalify(Astal.Window),
+
+    Box = astalify(Box, {}),
+
+    Entry = astalify(Gtk.Entry),
+
+    CenterBox = astalify(Gtk.CenterBox, {
+        set_children = function(self, children)
+            children = filter(children)
+            self.start_widget = children[1] or Gtk.Box({})
+            self.center_widget = children[2] or Gtk.Box({})
+            self.end_widget = children[3] or Gtk.Box({})
+        end,
+        ---@param self Gtk.CenterBox
+        get_children = function(self)
+            return { self.start_widget, self.center_widget, self.end_widget }
+        end,
+    }),
+
+    Label = astalify(Gtk.Label, {
+        set_children = function(self, children)
+            self.label = tostring(children)
+        end,
+        get_children = function()
+            return {}
+        end,
+    }),
+
+    Slider = astalify(Slider, {
+        get_children = function()
+            return {}
+        end,
+    }),
+
+    Button = astalify(Gtk.Button),
+
+    Image = astalify(Gtk.Image, {
+        get_children = function()
+            return {}
+        end,
+    }),
+
+    MenuButton = astalify(Gtk.MenuButton, {
+        set_children = function(self, children)
+            for _, child in ipairs(filter(children)) do
+                if Gtk.Popover:is_type_of(children) then
+                    self:set_popover(child)
+                else
+                    self:set_child(child)
+                end
+            end
+        end,
+        get_children = function(self)
+            return { self.popover, self.child }
+        end,
+    }),
+
+    Revealer = astalify(Gtk.Revealer, {}),
+
+    Switch = astalify(Gtk.Switch, {
+        get_children = function()
+            return {}
+        end,
+    }),
+
+    ProgressBar = astalify(Gtk.ProgressBar, {
+        get_children = function()
+            return {}
+        end,
+    }),
+}

--- a/astal/gtk4/widget.lua
+++ b/astal/gtk4/widget.lua
@@ -56,64 +56,7 @@ DrawingArea._attribute.draw_func = {
 --     end,
 -- }
 
----@param children any[]
----@return ( Gtk.Widget | Gtk.Label )[]
-local filter = function(children)
-    local function filter(tbl, fn)
-        local copy = {}
-        for key, value in pairs(tbl) do
-            if fn(value, key) then
-                if type(key) == 'number' then
-                    table.insert(copy, value)
-                else
-                    copy[key] = value
-                end
-            end
-        end
-        return copy
-    end
-
-    local function map(tbl, fn)
-        local copy = {}
-        for key, value in pairs(tbl) do
-            copy[key] = fn(value)
-        end
-        return copy
-    end
-
-    local function flatten(tbl)
-        local copy = {}
-        for _, value in pairs(tbl) do
-            if type(value) == 'table' and getmetatable(value) == nil then
-                for _, inner in pairs(flatten(value)) do
-                    table.insert(copy, inner)
-                end
-            else
-                table.insert(copy, value)
-            end
-        end
-        return copy
-    end
-
-    return map(
-        filter(flatten(children), function(item)
-            return not not item
-        end),
-        function(item)
-            if Gtk.Widget:is_type_of(item) then
-                return item
-            end
-            return Gtk.Label({
-                visible = true,
-                label = tostring(item),
-            })
-        end
-    )
-end
-
 return {
-    --- Utility function for container widgets
-    __filter = filter,
     astalify = astalify,
 
     DrawingArea = astalify(DrawingArea),
@@ -126,7 +69,7 @@ return {
                 self:remove(ch)
             end
 
-            for _, ch in ipairs(filter(children)) do
+            for _, ch in ipairs(children) do
                 self:append(ch)
             end
         end,
@@ -147,7 +90,6 @@ return {
 
     CenterBox = astalify(Gtk.CenterBox, {
         set_children = function(self, children)
-            children = filter(children)
             self.start_widget = children[1] or Gtk.Box({})
             self.center_widget = children[2] or Gtk.Box({})
             self.end_widget = children[3] or Gtk.Box({})
@@ -182,7 +124,7 @@ return {
 
     MenuButton = astalify(Gtk.MenuButton, {
         set_children = function(self, children)
-            for _, child in ipairs(filter(children)) do
+            for _, child in ipairs(children) do
                 if Gtk.Popover:is_type_of(children) then
                     self:set_popover(child)
                 else

--- a/astal/gtk4/widget.lua
+++ b/astal/gtk4/widget.lua
@@ -46,6 +46,16 @@ DrawingArea._attribute.draw_func = {
     end,
 }
 
+-- ---@type Gtk.Image | { pixbuf: GdkPixbuf.Pixbuf }
+-- local Image = Gtk.Image
+
+-- ---@diagnostic disable-next-line
+-- Image._attribute.pixbuf = {
+--     set = function(self, pixbuf)
+--         self:set_from_pixbuf(pixbuf)
+--     end,
+-- }
+
 ---@param children any[]
 ---@return ( Gtk.Widget | Gtk.Label )[]
 local filter = function(children)
@@ -102,6 +112,7 @@ local filter = function(children)
 end
 
 return {
+    --- Utility function for container widgets
     __filter = filter,
     astalify = astalify,
 
@@ -109,7 +120,28 @@ return {
 
     Window = astalify(Astal.Window),
 
-    Box = astalify(Box, {}),
+    Box = astalify(Box, {
+        set_children = function(self, children)
+            for _, ch in ipairs(self:get_children()) do
+                self:remove(ch)
+            end
+
+            for _, ch in ipairs(filter(children)) do
+                self:append(ch)
+            end
+        end,
+        get_children = function(self)
+            local children = {}
+            local child = self:get_first_child()
+
+            while child do
+                table.insert(children, child)
+                child = child:get_next_sibling()
+            end
+
+            return children
+        end,
+    }),
 
     Entry = astalify(Gtk.Entry),
 
@@ -120,7 +152,6 @@ return {
             self.center_widget = children[2] or Gtk.Box({})
             self.end_widget = children[3] or Gtk.Box({})
         end,
-        ---@param self Gtk.CenterBox
         get_children = function(self)
             return { self.start_widget, self.center_widget, self.end_widget }
         end,

--- a/astal/init.lua
+++ b/astal/init.lua
@@ -27,6 +27,24 @@ return {
     write_file_async = File.write_file_async,
     monitor_file = File.monitor_file,
 
+    ---@generic F: function
+    ---@param fn F
+    ---@return F
+    async = function(fn)
+        return function(...)
+            return lgi.Gio.Async.start(fn)(...)
+        end
+    end,
+
+    ---@generic F: function
+    ---@param fn F
+    ---@return F
+    await = function(fn)
+        return function(...)
+            return lgi.Gio.Async.call(fn)(...)
+        end
+    end,
+
     ---@generic T
     ---@type fun(libname: `T`, version?: string): T
     require = lgi.require,

--- a/astal/process.lua
+++ b/astal/process.lua
@@ -1,79 +1,185 @@
 local lgi = require('lgi')
+local Gio = lgi.require('Gio')
+local GLib = lgi.require('GLib')
 
----@type AstalIO
-local AstalIO = lgi.require('AstalIO', '0.1')
+---@generic F: function
+---@param fn F
+---@return F
+local async = function(fn)
+    return function(...)
+        return lgi.Gio.Async.start(fn)(...)
+    end
+end
+
+---@generic F: function
+---@param fn F
+---@return F
+local await = function(fn)
+    return function(...)
+        return lgi.Gio.Async.call(fn)(...)
+    end
+end
+
+---@class AstalLuaProcess
+---@field private subprocess Gio.Subprocess
+---@field private stdout_stream? Gio.DataInputStream
+---@field private stderr_stream? Gio.DataInputStream
+---@field private stdin_stream? Gio.DataOutputStream
+local Process = {}
+
+---@param command string | string[]
+---@param mode 'r' | 'w' | 'rw'
+---@return AstalLuaProcess
+Process.new = function(command, mode)
+    local argv
+
+    if type(command) == 'string' then
+        argv = GLib.shell_parse_argv(command) --- @diagnostic disable-line
+    else
+        argv = command
+    end
+
+    local p = setmetatable({ argv = argv, mode = mode }, { __index = Process })
+
+    local flags
+
+    if p.mode == 'rw' then
+        flags = { 'STDOUT_PIPE', 'STDERR_PIPE', 'STDIN_PIPE' }
+    elseif p.mode == 'r' then
+        flags = { 'STDOUT_PIPE', 'STDERR_PIPE' }
+    elseif p.mode == 'w' then
+        flags = { 'STDIN_PIPE' }
+    end
+
+    p.subprocess = Gio.Subprocess({
+        argv = p.argv,
+        flags = flags,
+    })
+
+    return p
+end
+
+Process.async_lines = function(self)
+    if not self.stdout_stream then
+        self.stdout_stream = Gio.DataInputStream.new(self.subprocess:get_stdout_pipe())
+    end
+
+    return function()
+        return self.stdout_stream:async_read_line()
+    end
+end
+
+Process.lines = function(self)
+    return await(self:async_lines())
+end
+
+---@param callback fun(line: string)
+Process.lines_async = async(function(self, callback)
+    for line in self:async_lines() do
+        callback(line)
+    end
+end)
+
+Process.async_errors = function(self)
+    if not self.stderr_stream then
+        self.stderr_stream = Gio.DataInputStream.new(self.subprocess:get_stderr_pipe())
+    end
+
+    return function()
+        return self.stderr_stream:async_read_line()
+    end
+end
+
+Process.errors = function(self)
+    return await(self:async_errors())
+end
+
+---@param callback fun(err: string)
+Process.errors_async = async(function(self, callback)
+    for err in self:async_errors() do
+        callback(err)
+    end
+end)
+
+---@param self AstalLuaProcess
+---@param ... integer | '*a' | '*l'
+Process.async_read = function(self, ...) end --- ToDo
+
+---@return boolean
+Process.async_wait = function(self)
+    return self.subprocess:async_wait()
+end
+---@return boolean
+Process.wait = await(function(self)
+    return self:async_wait()
+end)
+
+---@param self AstalLuaProcess
+---@param callback fun(ok: boolean)
+Process.wait_async = async(function(self, callback)
+    callback(self:async_wait())
+end)
+
+function Process:quit()
+    self.subprocess:force_exit()
+end
 
 local M = {}
 
-M.Process = AstalIO.Process
+--- Class that acts as io.popen using Gio.Subprocess as backend
+M.Process = Process
 
----@param commandline string | string[]
----@param on_stdout? fun(out: string): nil
----@param on_stderr? fun(err: string): nil
----@return { kill: function } | nil proc
-function M.subprocess(commandline, on_stdout, on_stderr)
-    on_stdout = on_stdout or function(out)
-        io.stdout:write(tostring(out) .. '\n')
-    end
+---@param command string | string[]
+---@param on_stdout? fun(out: string)
+---@param on_stderr? fun(err: string)
+M.subprocess = function(command, on_stdout, on_stderr)
+    local p = Process.new(command, 'r')
 
-    on_stderr = on_stderr or function(err)
-        io.stderr:write(tostring(err) .. '\n')
-    end
+    p:lines_async(on_stdout or function(out)
+        io.stdout:write(('%s\n'):format(out))
+    end)
 
-    local proc, err
+    p:errors_async(on_stderr or function(err)
+        io.stderr:write(('%s\n'):format(err))
+    end)
 
-    if type(commandline) == 'table' then
-        proc, err = AstalIO.Process.subprocessv(commandline)
-    else
-        proc, err = AstalIO.Process.subprocess(commandline)
-    end
-
-    if err ~= nil then
-        return error(err)
-    end
-
-    proc.on_stdout = function(_, stdout)
-        on_stdout(stdout)
-    end
-    proc.on_stderr = function(_, stderr)
-        on_stderr(stderr)
-    end
-    return proc
+    return p
 end
 
----@param commandline string | string[]
----@return string, string
-function M.exec(commandline)
-    if type(commandline) == 'table' then
-        return AstalIO.Process.execv(commandline)
-    else
-        return AstalIO.Process.exec(commandline)
-    end
-end
+---@param command string | string[]
+M.async_exec = function(command)
+    local p = Process.new(command, 'r')
+    local ok = p:async_wait()
+    local lines = {}
 
----@param commandline string | string[]
----@param callback? fun(out: string, err: string): nil
-function M.exec_async(commandline, callback)
-    callback = callback
-        or function(out, err)
-            if err ~= nil then
-                io.stderr:write(tostring(out) .. '\n')
-            else
-                io.stdout:write(tostring(err) .. '\n')
-            end
+    if ok then
+        for line in p:async_lines() do
+            table.insert(lines, line)
         end
 
-    if type(commandline) == 'table' then
-        AstalIO.Process.exec_asyncv(commandline, function(_, res)
-            local out, err = AstalIO.Process.exec_asyncv_finish(res)
-            callback(out, err)
-        end)
+        return table.concat(lines, '\n')
     else
-        AstalIO.Process.exec_async(commandline, function(_, res)
-            local out, err = AstalIO.Process.exec_finish(res)
-            callback(out, err)
-        end)
+        for err in p:async_errors() do
+            table.insert(lines, err)
+        end
+
+        return nil, table.concat(lines, '\n')
     end
 end
+
+---@param command string | string[]
+---@return string?, string?
+M.exec = await(function(command)
+    return M.async_exec(command)
+end)
+
+---@param command string | string[]
+---@param callback? fun(stdout: string?, stderr?: string)
+M.exec_async = async(function(command, callback)
+    local stdout, stderr = M.async_exec(command)
+    if callback then
+        callback(stdout, stderr)
+    end
+end)
 
 return M

--- a/astal/requests.lua
+++ b/astal/requests.lua
@@ -1,0 +1,168 @@
+local astal = require('astal')
+local Soup = astal.require('Soup', '3.0')
+local Gio = astal.require('Gio', '2.0')
+local GLib = astal.require('GLib', '2.0')
+local async, await = astal.async, astal.await
+
+---@alias Requests.ResponseCtorArgs { url: string, status_code: number, ok: boolean, reason_phrase: string, text: string, bytes: GLib.Bytes, body:  Gio.InputStream }
+
+---@class Requests.Response
+---@field url string
+---@field status_code number
+---@field ok boolean
+---@field reason_phrase string
+---@field text string
+---@field bytes GLib.Bytes
+---@field body Gio.InputStream
+---@overload fun(args: Requests.ResponseCtorArgs): Requests.Response
+local Response = {}
+
+Response.__index = Response
+
+Response.__newindex = function(_, k)
+    io.stderr:write(string.format("Requests.Response: '%s' property is read-only\n", k))
+end
+
+---@param args Requests.ResponseCtorArgs
+Response.new = function(args)
+    return setmetatable({
+        url = args.url,
+        status_code = args.status_code,
+        ok = args.ok,
+        reason_phrase = args.reason_phrase,
+        text = args.text,
+        bytes = args.bytes,
+        body = args.body,
+    }, Response)
+end
+
+-- function Response:json() return json.decode(self.text) end
+
+---@param params table<string, any>
+---@param parent_key string | nil
+---@return string
+local function encode_query_params(params, parent_key)
+    local encoded_params = {}
+    local encoded_val, encoded_key
+
+    for key, value in pairs(params) do
+        local full_key = parent_key and (parent_key .. '[' .. key .. ']') or key
+        encoded_key = GLib.Uri.escape_string(tostring(full_key), nil, true)
+
+        if type(value) == 'table' then
+            table.insert(encoded_params, encode_query_params(value, full_key))
+        else
+            encoded_val = GLib.Uri.escape_string(tostring(value), nil, true)
+            table.insert(encoded_params, encoded_key .. '=' .. encoded_val)
+        end
+    end
+    return table.concat(encoded_params, '&')
+end
+
+---@class Requests
+local Requests = {}
+
+---@class RequestsRequestArgs
+---@field url string
+---@field params? table<string, any>
+---@field headers? table<string, string> | { ["Content-Type"]: 'application/json' | 'text/plain' | 'application/x-www-form-urlencoded' }
+---@field body? string
+
+---@param method "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
+---@param args RequestsRequestArgs
+---@return Requests.Response
+function Requests.async_request(method, args)
+    local session = Soup.Session.new()
+
+    local content_type = 'text/plain'
+
+    if args.params then
+        args.url = string.format('%s?%s', args.url, encode_query_params(args.params))
+    end
+
+    local message = Soup.Message.new_from_uri(method, GLib.Uri.parse(args.url, 'NONE'))
+
+    if args.headers then
+        for header_name, header_value in pairs(args.headers) do
+            if header_name == 'Content-Type' then
+                content_type = header_name
+            else
+                message:get_request_headers():append(header_name, header_value)
+            end
+        end
+    end
+
+    if type(args.body) == 'string' then
+        message:set_request_body_from_bytes(content_type, GLib.Bytes(args.body, #args.body))
+    end
+
+    local input_stream = session:async_send(message)
+    local output_stream = Gio.MemoryOutputStream.new_resizable()
+
+    output_stream:async_splice(input_stream, { 'CLOSE_SOURCE', 'CLOSE_TARGET' })
+
+    local bytes = output_stream:steal_as_bytes()
+
+    return Response.new({
+        body = input_stream,
+        text = bytes:get_data(bytes:get_size()),
+        bytes = bytes,
+        url = args.url,
+        status_code = message.status_code,
+        ok = message.status_code >= 200 and message.status_code < 300,
+        reason_phrase = message.reason_phrase,
+    })
+end
+
+Requests.request_async = async(
+    ---@param method "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
+    ---@param args RequestsRequestArgs
+    ---@param callback fun(res: Requests.Response)
+    function(method, args, callback)
+        callback(Requests.async_request(method, args))
+    end
+)
+
+---@param method "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
+---@param args RequestsRequestArgs
+---@return Requests.Response
+Requests.request = await(function(method, args)
+    return Requests.async_request(method, args)
+end)
+
+---@param args RequestsRequestArgs
+Requests.async_get = function(args)
+    return Requests.async_request('GET', args)
+end
+
+---@param args RequestsRequestArgs
+Requests.get_async = async(function(args, callback)
+    return callback(Requests.async_get(args))
+end)
+
+---@param args RequestsRequestArgs
+Requests.get = await(function(args)
+    return Requests.async_get(args)
+end)
+
+---@param args RequestsRequestArgs
+Requests.async_post = function(args)
+    return Requests.async_request('POST', args)
+end
+
+---@param args RequestsRequestArgs
+Requests.async_put = function(args)
+    return Requests.async_request('PUT', args)
+end
+
+---@param args RequestsRequestArgs
+Requests.async_delete = function(args)
+    return Requests.async_request('DELETE', args)
+end
+
+---@param args RequestsRequestArgs
+Requests.async_patch = function(args)
+    return Requests.async_request('PATCH', args)
+end
+
+return Requests

--- a/astal/time.lua
+++ b/astal/time.lua
@@ -1,30 +1,47 @@
 local lgi = require('lgi')
----@type AstalIO
-local AstalIO = lgi.require('AstalIO', '0.1')
-local GObject = lgi.require('GObject', '2.0')
+local GLib = lgi.require('GLib')
 
 local M = {}
 
-M.Time = AstalIO.Time
-
 ---@param interval number
 ---@param fn function
----@return { cancel: function, on_now: function }
+---@return function
 function M.interval(interval, fn)
-    return AstalIO.Time.interval(interval, GObject.Closure(fn))
+    local id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval, function()
+        fn()
+        return true
+    end)
+
+    return function()
+        GLib.source_remove(id)
+    end
 end
 
 ---@param timeout number
 ---@param fn function
----@return { cancel: function, on_now: function }
+---@return function
 function M.timeout(timeout, fn)
-    return AstalIO.Time.timeout(timeout, GObject.Closure(fn))
+    local id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timeout, function()
+        fn()
+        return false
+    end)
+
+    return function()
+        GLib.source_remove(id)
+    end
 end
 
 ---@param fn function
----@return { cancel: function, on_now: function }
+---@return function
 function M.idle(fn)
-    return AstalIO.Time.idle(GObject.Closure(fn))
+    local id = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, function()
+        fn()
+        return false
+    end)
+
+    return function()
+        GLib.source_remove(id)
+    end
 end
 
 return M

--- a/astal/variable.lua
+++ b/astal/variable.lua
@@ -5,6 +5,8 @@ local GObject = lgi.require('GObject', '2.0')
 local Process = require('astal.process')
 local Time = require('astal.time')
 
+---@alias Connectable GObject.Object | AstalLuaVariable | { subscribe: function }
+
 ---@class AstalLuaVariable: GObject.Object
 ---@field value any
 ---@field private priv { poll_cancel: function }

--- a/astal/variable.lua
+++ b/astal/variable.lua
@@ -1,6 +1,5 @@
 local lgi = require('lgi')
 
----@type GObject
 local GObject = lgi.require('GObject', '2.0')
 local Process = require('astal.process')
 local Time = require('astal.time')
@@ -9,7 +8,7 @@ local Time = require('astal.time')
 
 ---@class AstalLuaVariable: GObject.Object
 ---@field value any
----@field private priv { poll_cancel: function }
+---@field private priv table
 ---@field private _name "AstalLuaVariable"
 ---@field private _attribute table
 ---@field private _property table
@@ -124,7 +123,7 @@ end
 
 function Variable:stop_watch()
     if self:is_watching() then
-        self.priv.watch:kill()
+        self.priv.watch:quit()
     end
     self.priv.watch = nil
 end

--- a/bin/init.lua
+++ b/bin/init.lua
@@ -1,0 +1,154 @@
+#!/usr/bin/env lua
+
+local lgi = require('lgi')
+local Gio = lgi.require('Gio')
+local GLib = lgi.require('GLib')
+local argparse = require('argparse')
+
+local IFACE = 'io.Astal.Application'
+local PATH = '/io/Astal/Application'
+
+local function printerr(fmt, ...)
+    io.stderr:write(('\27[31mError:\27[0m ' .. fmt .. '\n'):format(...))
+end
+
+---@return string[]
+local function list_instances()
+    local conn = Gio.bus_get_sync('SESSION')
+
+    local response = conn:call_sync(
+        'org.freedesktop.DBus',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus',
+        'ListNames',
+        GLib.Variant('()', {}),
+        GLib.VariantType('(as)'),
+        { 'NONE' },
+        -1
+    )
+
+    local instances = {}
+    local prefix = 'io.Astal.'
+    for _, name in response.value[1]:ipairs() do
+        if name:sub(1, #prefix) == prefix then
+            table.insert(instances, name:sub(#prefix + 1))
+        end
+    end
+    return instances
+end
+
+---@return boolean
+local function is_running(name)
+    for _, instance in ipairs(list_instances()) do
+        if instance == name then
+            return true
+        end
+    end
+    return false
+end
+
+local function call_method(instance_name, method, args)
+    local conn = Gio.bus_get_sync('SESSION')
+    local name = string.format('io.Astal.%s', instance_name)
+    local vtype = GLib.VariantType(method == 'Request' and '(s)' or '()')
+
+    return conn:call_sync(name, PATH, IFACE, method, args, vtype, { 'NONE' }, -1)
+end
+
+local function main()
+    local parser =
+        argparse():name('astal-lua'):description('CLI for controlling Astal application instances.')
+
+    parser:command('list'):summary('List active instances.')
+
+    -- Startup Options
+    local run = parser:command('run'):summary('Run an Astal application instance.'):description(
+        'Starts a new Astal application by running the given Lua entry point file.'
+    )
+
+    run:argument('file', 'Entry point Lua file.', './init.lua')
+    run:option('--lua-version', 'Specify Lua version to run.', 'jit'):argname('<ver>')
+    run:flag('--gtk4', 'Use GTK4 layer-shell.')
+    run:flag('--gdk-wayland', 'Use GDK backend Wayland.')
+    run:flag('--nvidia', 'Use GBM backend NVIDIA.')
+    run:flag('--vulkan', 'Force Vulkan renderer in GTK4.')
+
+    -- Request Methods
+    local request = parser
+        :command('request')
+        :summary('Send a request to a running Astal instance.')
+        :description('Communicates with an already running Astal application instance over D-Bus.')
+
+    request:argument('args', 'A list of arguments to send to Astal.Application.'):args('*')
+    request
+        :option('-i --instance', 'Instance name of the Astal.Application.', 'lua')
+        :argname('<name>')
+    request:option('-t --toggle-window', 'Show or hide a window.'):argname('<name>')
+    request:flag('-q --quit', 'Quit a running instance.')
+    request:flag('-I --inspector', 'Open GTK inspector/debug tool.')
+
+    local args = parser:parse()
+
+    local instance_name = args.instance
+
+    if args.list then
+        for _, inst in ipairs(list_instances()) do
+            print(inst)
+        end
+        return 0
+    end
+
+    if args.run then
+        if args.gtk4 then
+            GLib.setenv('LD_PRELOAD', '/usr/lib/libgtk4-layer-shell.so')
+        end
+
+        if args.gdk_wayland then
+            GLib.setenv('GDK_BACKEND', 'wayland,x11')
+        end
+
+        if args.nvidia then
+            GLib.setenv('GBM_BACKEND', 'nvidia-drm')
+        end
+
+        if args.vulkan then
+            GLib.setenv('GSK_RENDERER', 'vulkan')
+        end
+
+        return os.execute(string.format('lua%s %s', args.lua_version, args.file))
+    end
+
+    if args.request then
+        if args.instance and not is_running(instance_name) then
+            printerr("Instance '%s' is not running", instance_name)
+            return 1
+        end
+
+        if args.inspector then
+            call_method(instance_name, 'Inspector', GLib.Variant('()'))
+        end
+
+        if args.quit then
+            call_method(instance_name, 'Quit', GLib.Variant('()'))
+        end
+
+        if args.toggle_window then
+            call_method(instance_name, 'ToggleWindow', GLib.Variant('(s)', { args.toggle_window }))
+        end
+
+        if args.args then
+            local variant =
+                call_method(instance_name, 'Request', GLib.Variant('(as)', { args.args }))
+            if variant then
+                print(variant.value[1])
+            else
+                printerr("Instance '%s' did't give a response", instance_name)
+                return 1
+            end
+        end
+
+        return 0
+    end
+end
+
+return os.exit(main())

--- a/examples/gtk3/applauncher/init.lua
+++ b/examples/gtk3/applauncher/init.lua
@@ -1,5 +1,5 @@
+require("astal.gtk3")
 local astal = require("astal")
-local App = require("astal.gtk3.app")
 
 local AppLauncher = require("widget.Applauncher")
 local src = require("lib").src
@@ -8,6 +8,8 @@ local scss = src("style.scss")
 local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
+
+local App = require("astal.gtk3.app")
 
 App:start({
 	instance_name = "launcher",

--- a/examples/gtk3/applauncher/widget/Applauncher.lua
+++ b/examples/gtk3/applauncher/widget/Applauncher.lua
@@ -1,12 +1,11 @@
 local astal = require("astal")
 
 local Apps = astal.require("AstalApps")
-local App = require("astal.gtk3.app")
-local Astal = require("astal.gtk3").Astal
+local Widget = require("astal.gtk3.widget")
 local Gdk = require("astal.gtk3").Gdk
+local App = require("astal.gtk3.app")
 local Variable = astal.Variable
 local bind = astal.bind
-local Widget = require("astal.gtk3.widget")
 
 local slice = require("lib").slice
 local map = require("lib").map

--- a/examples/gtk3/media-player/init.lua
+++ b/examples/gtk3/media-player/init.lua
@@ -1,5 +1,4 @@
 local astal = require("astal")
-local App = require("astal.gtk3.app")
 local Widget = require("astal.gtk3.widget")
 
 local MprisPlayers = require("widget.MediaPlayer")
@@ -10,10 +9,10 @@ local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
 
+local App = require("astal.gtk3.app")
+
 App:start({
 	instance_name = "lua",
 	css = css,
-	main = function()
-		Widget.Window({ MprisPlayers() })
-	end,
+	main = function() Widget.Window({ MprisPlayers() }) end,
 })

--- a/examples/gtk3/notifications/init.lua
+++ b/examples/gtk3/notifications/init.lua
@@ -1,5 +1,4 @@
 local astal = require("astal")
-local App = require("astal.gtk3.app")
 
 local NotificationPopups = require("notifications.NotificationPopups")
 local src = require("lib").src
@@ -8,6 +7,8 @@ local scss = src("style.scss")
 local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
+
+local App = require("astal.gtk3.app")
 
 App:start({
 	instance_name = "notifications",

--- a/examples/gtk3/simple-bar/init.lua
+++ b/examples/gtk3/simple-bar/init.lua
@@ -1,5 +1,5 @@
+require("astal.gtk3")
 local astal = require("astal")
-local App = require("astal.gtk3.app")
 
 local Bar = require("widget.Bar")
 local src = require("lib").src
@@ -9,11 +9,13 @@ local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
 
+local App = require("astal.gtk3.app")
+
 App:start({
 	instance_name = "lua",
 	css = css,
-	request_handler = function(msg, res)
-		print(msg)
+	request_handler = function(args, res)
+		print(table.unpack(args))
 		res("ok")
 	end,
 	main = function()

--- a/examples/gtk4/applauncher/README.md
+++ b/examples/gtk4/applauncher/README.md
@@ -1,0 +1,5 @@
+# Applauncher
+
+![launcher](https://github.com/user-attachments/assets/2695e3bb-dff4-478a-b392-279fe638bfd3)
+
+Using [Apps](https://aylur.github.io/astal/guide/libraries/apps).

--- a/examples/gtk4/applauncher/init.lua
+++ b/examples/gtk4/applauncher/init.lua
@@ -1,0 +1,16 @@
+local astal = require("astal")
+local App = require("astal.gtk4.app")
+
+local AppLauncher = require("widget.Applauncher")
+local src = require("lib").src
+
+local scss = src("style.scss")
+local css = "/tmp/style.css"
+
+astal.exec("sass " .. scss .. " " .. css)
+
+App:start({
+	instance_name = "launcher",
+	css = css,
+	main = AppLauncher,
+})

--- a/examples/gtk4/applauncher/init.lua
+++ b/examples/gtk4/applauncher/init.lua
@@ -1,5 +1,4 @@
 local astal = require("astal")
-local App = require("astal.gtk4.app")
 
 local AppLauncher = require("widget.Applauncher")
 local src = require("lib").src
@@ -8,6 +7,8 @@ local scss = src("style.scss")
 local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
+
+local App = require("astal.gtk4.app")
 
 App:start({
 	instance_name = "launcher",

--- a/examples/gtk4/applauncher/lib.lua
+++ b/examples/gtk4/applauncher/lib.lua
@@ -1,0 +1,38 @@
+local M = {}
+
+function M.src(path)
+	local str = debug.getinfo(2, "S").source:sub(2)
+	local src = str:match("(.*/)") or str:match("(.*\\)") or "./"
+	return src .. path
+end
+
+---@generic T, R
+---@param array T[]
+---@param func fun(T, i: integer): R
+---@return R[]
+function M.map(array, func)
+	local new_arr = {}
+	for i, v in ipairs(array) do
+		new_arr[i] = func(v, i)
+	end
+	return new_arr
+end
+
+---@generic T
+---@param array T[]
+---@param start integer
+---@param stop? integer
+---@return T[]
+function M.slice(array, start, stop)
+	local new_arr = {}
+
+	stop = stop or #array
+
+	for i = start, stop do
+		table.insert(new_arr, array[i])
+	end
+
+	return new_arr
+end
+
+return M

--- a/examples/gtk4/applauncher/style.scss
+++ b/examples/gtk4/applauncher/style.scss
@@ -1,0 +1,1 @@
+@use "./widget/Applauncher.scss"

--- a/examples/gtk4/applauncher/widget/Applauncher.lua
+++ b/examples/gtk4/applauncher/widget/Applauncher.lua
@@ -1,0 +1,125 @@
+local astal = require("astal")
+
+local Apps = astal.require("AstalApps")
+local App = require("astal.gtk4.app")
+local Widget = require("astal.gtk4.widget")
+local Gdk = require("astal.gtk4").Gdk
+local Variable = astal.Variable
+local bind = astal.bind
+
+local slice = require("lib").slice
+local map = require("lib").map
+
+local MAX_ITEMS = 8
+
+local function hide()
+	local launcher = App:get_window("launcher")
+	if launcher then launcher:hide() end
+end
+
+local function AppButton(app)
+	return Widget.Button({
+		css_classes = { "AppButton" },
+		on_clicked = function()
+			hide()
+			app:launch()
+		end,
+		Widget.Box({
+			Widget.Image({ icon_name = app.icon_name, pixel_size = 32 }),
+			Widget.Box({
+				valign = "CENTER",
+				vertical = true,
+				Widget.Label({
+					css_classes = { "name" },
+					wrap = true,
+					xalign = 0,
+					label = app.name,
+				}),
+				app.description and Widget.Label({
+					css_classes = { "description" },
+					wrap = true,
+					xalign = 0,
+					label = app.description,
+				}),
+			}),
+		}),
+	})
+end
+
+return function()
+	local apps = Apps.Apps()
+
+	local text = Variable.new("")
+	local list = bind(text):as(
+		function(t) return slice(apps:fuzzy_query(t), 1, MAX_ITEMS) end
+	)
+
+	local on_enter = function()
+		local found = apps:fuzzy_query(text:get())[1]
+		if found then
+			found:launch()
+			hide()
+		end
+	end
+
+	return Widget.Window({
+		name = "launcher",
+		anchor = { "TOP", "BOTTOM" },
+		exclusivity = "IGNORE",
+		keymode = "ON_DEMAND",
+		application = App,
+		on_show = function() text:set("") end,
+		on_hide = function() App:quit(0) end,
+		on_key_pressed = function(self, keyval)
+			if keyval == Gdk.KEY_Escape then self:hide() end
+		end,
+		Widget.Box({
+			Widget.Box({
+				hexpand = true,
+				vexpand = true,
+				on_button_pressed = hide,
+				width_request = 4000,
+			}),
+			Widget.Box({
+				hexpand = false,
+				vertical = true,
+				Widget.Box({ on_button_pressed = hide, height_request = 100 }),
+				Widget.Box({
+					vertical = true,
+					width_request = 500,
+					css_classes = { "Applauncher" },
+					Widget.Entry({
+						placeholder_text = "Search",
+						-- text = bind(text),
+						on_changed = function(self) text:set(self.text) end,
+						on_activate = on_enter,
+					}),
+					Widget.Box({
+						spacing = 6,
+						vertical = true,
+						list:as(function(l) return map(l, AppButton) end),
+					}),
+					Widget.Box({
+						halign = "CENTER",
+						css_classes = { "not-found" },
+						vertical = true,
+						visible = list:as(function(l) return #l == 0 end),
+						Widget.Image({ icon_name = "system-search-symbolic" }),
+						Widget.Label({ label = "No match found" }),
+					}),
+				}),
+				Widget.Box({
+					vexpand = true,
+					hexpand = true,
+					on_button_pressed = hide,
+				}),
+			}),
+			Widget.Box({
+				width_request = 4000,
+				hexpand = true,
+				vexpand = true,
+				on_button_pressed = hide,
+			}),
+		}),
+	})
+end

--- a/examples/gtk4/applauncher/widget/Applauncher.lua
+++ b/examples/gtk4/applauncher/widget/Applauncher.lua
@@ -25,20 +25,22 @@ local function AppButton(app)
 			app:launch()
 		end,
 		Widget.Box({
-			Widget.Image({ icon_name = app.icon_name, pixel_size = 32 }),
+			Widget.Image({ icon_name = app.icon_name, pixel_size = 48 }),
 			Widget.Box({
 				valign = "CENTER",
 				vertical = true,
 				Widget.Label({
 					css_classes = { "name" },
-					wrap = true,
 					xalign = 0,
+					ellipsize = "END",
+					max_width_chars = 10,
 					label = app.name,
 				}),
 				app.description and Widget.Label({
 					css_classes = { "description" },
-					wrap = true,
 					xalign = 0,
+					ellipsize = "END",
+					max_width_chars = 30,
 					label = app.description,
 				}),
 			}),
@@ -64,7 +66,7 @@ return function()
 
 	return Widget.Window({
 		name = "launcher",
-		anchor = { "TOP", "BOTTOM" },
+		anchor = { "TOP", "LEFT", "RIGHT", "BOTTOM" },
 		exclusivity = "IGNORE",
 		keymode = "ON_DEMAND",
 		application = App,
@@ -78,7 +80,7 @@ return function()
 				hexpand = true,
 				vexpand = true,
 				on_button_pressed = hide,
-				width_request = 4000,
+				-- width_request = 4000,
 			}),
 			Widget.Box({
 				hexpand = false,
@@ -90,7 +92,6 @@ return function()
 					css_classes = { "Applauncher" },
 					Widget.Entry({
 						placeholder_text = "Search",
-						-- text = bind(text),
 						on_changed = function(self) text:set(self.text) end,
 						on_activate = on_enter,
 					}),
@@ -104,7 +105,10 @@ return function()
 						css_classes = { "not-found" },
 						vertical = true,
 						visible = list:as(function(l) return #l == 0 end),
-						Widget.Image({ icon_name = "system-search-symbolic" }),
+						Widget.Image({
+							icon_name = "system-search-symbolic",
+							pixel_size = 96,
+						}),
 						Widget.Label({ label = "No match found" }),
 					}),
 				}),
@@ -115,7 +119,7 @@ return function()
 				}),
 			}),
 			Widget.Box({
-				width_request = 4000,
+				-- width_request = 4000,
 				hexpand = true,
 				vexpand = true,
 				on_button_pressed = hide,

--- a/examples/gtk4/applauncher/widget/Applauncher.scss
+++ b/examples/gtk4/applauncher/widget/Applauncher.scss
@@ -1,0 +1,59 @@
+@use 'sass:string';
+
+@function gtkalpha($c, $a) {
+    @return string.unquote('alpha(#{$c},#{$a})');
+}
+
+// https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gtk/theme/Adwaita/_colors-public.scss
+$fg-color: #{'@theme_fg_color'};
+$bg-color: #{'@theme_bg_color'};
+
+window#launcher {
+    all: unset;
+
+    box.Applauncher {
+        background-color: $bg-color;
+        border-radius: 11px;
+        margin: 1rem;
+        padding: 0.8rem;
+        box-shadow: 2px 3px 8px 0 gtkalpha(black, 0.4);
+
+        entry {
+            margin-bottom: 0.8rem;
+        }
+
+        button {
+            min-width: 0;
+            min-height: 0;
+            padding: 0.5rem;
+
+            icon {
+                font-size: 3em;
+                margin-right: 0.3rem;
+            }
+
+            label.name {
+                font-weight: bold;
+                font-size: 1.1em;
+            }
+
+            label.description {
+                color: gtkalpha($fg-color, 0.8);
+            }
+        }
+
+        box.not-found {
+            padding: 1rem;
+
+            icon {
+                font-size: 6em;
+                color: gtkalpha($fg-color, 0.7);
+            }
+
+            label {
+                color: gtkalpha($fg-color, 0.9);
+                font-size: 1.2em;
+            }
+        }
+    }
+}

--- a/examples/gtk4/applauncher/widget/Applauncher.scss
+++ b/examples/gtk4/applauncher/widget/Applauncher.scss
@@ -27,8 +27,7 @@ window#launcher {
             min-height: 0;
             padding: 0.5rem;
 
-            icon {
-                font-size: 3em;
+            image {
                 margin-right: 0.3rem;
             }
 
@@ -45,8 +44,7 @@ window#launcher {
         box.not-found {
             padding: 1rem;
 
-            icon {
-                font-size: 6em;
+            image{
                 color: gtkalpha($fg-color, 0.7);
             }
 

--- a/examples/gtk4/simple-bar/README.md
+++ b/examples/gtk4/simple-bar/README.md
@@ -1,0 +1,13 @@
+# Simple Bar Example
+
+![simple-bar](https://github.com/user-attachments/assets/a306c864-56b7-44c4-8820-81f424f32b9b)
+
+A simple bar for Hyprland using
+
+- [Battery library](https://aylur.github.io/astal/guide/libraries/battery).
+- [Hyprland library](https://aylur.github.io/astal/guide/libraries/hyprland).
+- [Mpris library](https://aylur.github.io/astal/guide/libraries/mpris).
+- [Network library](https://aylur.github.io/astal/guide/libraries/network).
+- [Tray library](https://aylur.github.io/astal/guide/libraries/tray).
+- [WirePlumber library](https://aylur.github.io/astal/guide/libraries/wireplumber).
+- [dart-sass](https://sass-lang.com/dart-sass/) as the css precompiler

--- a/examples/gtk4/simple-bar/init.lua
+++ b/examples/gtk4/simple-bar/init.lua
@@ -1,5 +1,4 @@
 local astal = require("astal")
-local App = require("astal.gtk4.app")
 
 local Bar = require("widget.Bar")
 local src = require("lib").src
@@ -8,6 +7,8 @@ local scss = src("style.scss")
 local css = "/tmp/style.css"
 
 astal.exec("sass " .. scss .. " " .. css)
+
+local App = require("astal.gtk4.app")
 
 App:start({
 	instance_name = "lua",

--- a/examples/gtk4/simple-bar/init.lua
+++ b/examples/gtk4/simple-bar/init.lua
@@ -1,0 +1,24 @@
+local astal = require("astal")
+local App = require("astal.gtk4.app")
+
+local Bar = require("widget.Bar")
+local src = require("lib").src
+
+local scss = src("style.scss")
+local css = "/tmp/style.css"
+
+astal.exec("sass " .. scss .. " " .. css)
+
+App:start({
+	instance_name = "lua",
+	css = css,
+	request_handler = function(msg, res)
+		print(msg)
+		res("ok")
+	end,
+	main = function()
+		for _, mon in pairs(App.monitors) do
+			Bar(mon)
+		end
+	end,
+})

--- a/examples/gtk4/simple-bar/lib.lua
+++ b/examples/gtk4/simple-bar/lib.lua
@@ -1,0 +1,25 @@
+local Variable = require("astal").Variable
+
+local M = {}
+
+function M.src(path)
+	local str = debug.getinfo(2, "S").source:sub(2)
+	local src = str:match("(.*/)") or str:match("(.*\\)") or "./"
+	return src .. path
+end
+
+---@generic T, R
+---@param array T[]
+---@param func fun(T, i: integer): R
+---@return R[]
+function M.map(array, func)
+	local new_arr = {}
+	for i, v in ipairs(array) do
+		new_arr[i] = func(v, i)
+	end
+	return new_arr
+end
+
+M.date = Variable.new(""):poll(1000, "date")
+
+return M

--- a/examples/gtk4/simple-bar/style.scss
+++ b/examples/gtk4/simple-bar/style.scss
@@ -1,0 +1,106 @@
+@use "sass:color";
+
+$bg: #212223;
+$fg: #f1f1f1;
+$accent: #378DF7;
+$radius: 7px;
+
+window.Bar {
+    border: none;
+    box-shadow: none;
+    background-color: $bg;
+    color: $fg;
+    font-size: 1.1em;
+    font-weight: bold;
+
+    label {
+        margin: 0 8px;
+    }
+
+    .Workspaces  {
+        button {
+            all: unset;
+            background-color: transparent;
+
+            &:hover label {
+                background-color: color.adjust($fg, $alpha: -0.84);
+                border-color: color.adjust($accent, $alpha: -0.8);
+            }
+
+            &:active label {
+                background-color: color.adjust($fg, $alpha: -0.8)
+            }
+        }
+
+        label {
+            transition: 200ms;
+            padding: 0 8px;
+            margin: 2px;
+            border-radius: $radius;
+            border: 1pt solid transparent;
+        }
+
+        .focused label {
+            color: $accent;
+            border-color: $accent;
+        }
+    }
+
+    .SysTray {
+        margin-right: 8px;
+
+        button {
+            padding: 0 4px;
+        }
+    }
+
+    .FocusedClient {
+        color: $accent;
+    }
+
+    .Media .Cover {
+        min-height: 1.2em;
+        min-width: 1.2em;
+        border-radius: $radius;
+        background-position: center;
+        background-size: contain;
+    }
+
+    .Battery label {
+        padding-left: 0;
+        margin-left: 0;
+    }
+
+    .AudioSlider {
+        * {
+            all: unset;
+        }
+
+        icon {
+            margin-right: .6em;
+        }
+
+        & {
+            margin: 0 1em;
+        }
+
+        trough {
+            background-color: color.adjust($fg, $alpha: -0.8);
+            border-radius: $radius;
+        }
+
+        highlight {
+            background-color: $accent;
+            min-height: .8em;
+            border-radius: $radius;
+        }
+
+        slider {
+            background-color: $fg;
+            border-radius: $radius;
+            min-height: 1em;
+            min-width: 1em;
+            margin: -.2em;
+        }
+    }
+}

--- a/examples/gtk4/simple-bar/widget/Bar.lua
+++ b/examples/gtk4/simple-bar/widget/Bar.lua
@@ -1,0 +1,199 @@
+local astal = require("astal")
+local Widget = require("astal.gtk4.widget")
+local Variable = require("astal.variable")
+local GLib = astal.require("GLib")
+local bind = astal.bind
+local Mpris = astal.require("AstalMpris")
+local Battery = astal.require("AstalBattery")
+local Wp = astal.require("AstalWp")
+local Network = astal.require("AstalNetwork")
+local Tray = astal.require("AstalTray")
+local Hyprland = astal.require("AstalHyprland")
+local map = require("lib").map
+
+local function SysTray()
+	local tray = Tray.get_default()
+
+	return Widget.Box({
+		css_classes = { "SysTray" },
+		bind(tray, "items"):as(function(items)
+			return map(items, function(item)
+				return Widget.MenuButton({
+					tooltip_markup = bind(item, "tooltip_markup"),
+					menu_model = bind(item, "menu-model"),
+					action_group = bind(item, "action-group"):as(
+						function(ag) return { "dbusmenu", ag } end
+					),
+					Widget.Image({
+						gicon = bind(item, "gicon"),
+					}),
+				})
+			end)
+		end),
+	})
+end
+
+local function FocusedClient()
+	local hypr = Hyprland.get_default()
+	local focused = bind(hypr, "focused-client")
+
+	return Widget.Box({
+		css_classes = { "Focused" },
+		visible = focused,
+		focused:as(
+			function(client)
+				return client
+					and Widget.Label({
+						label = bind(client, "title"):as(tostring),
+					})
+			end
+		),
+	})
+end
+
+local function Wifi()
+	local network = Network.get_default()
+	local wifi = bind(network, "wifi")
+
+	return Widget.Box({
+		visible = wifi:as(function(v) return v ~= nil end),
+		wifi:as(
+			function(w)
+				return Widget.Image({
+					tooltip_text = bind(w, "ssid"):as(tostring),
+					css_classes = { "Wifi" },
+					icon_name = bind(w, "icon-name"),
+				})
+			end
+		),
+	})
+end
+
+local function AudioSlider()
+	local speaker = Wp.get_default().audio.default_speaker
+
+	return Widget.Box({
+		css_classes = { "AudioSlider" },
+		width_request = 140,
+		Widget.Image({
+			icon_name = bind(speaker, "volume-icon"),
+		}),
+		Widget.Slider({
+			hexpand = true,
+			-- value = bind(speaker, "volume"),
+			-- on_value_changed = function(self) speaker.volume = self.value end,
+			setup = function(self)
+				self:bind_property("value", speaker, "volume", "BIDIRECTIONAL")
+			end,
+		}),
+	})
+end
+
+local function BatteryLevel()
+	local bat = Battery.get_default()
+
+	return Widget.Box({
+		css_classes = { "Battery" },
+		visible = bind(bat, "is-present"),
+		Widget.Image({
+			icon_name = bind(bat, "battery-icon-name"),
+		}),
+		Widget.Label({
+			label = bind(bat, "percentage"):as(
+				function(p) return tostring(math.floor(p * 100)) .. " %" end
+			),
+		}),
+	})
+end
+
+local function Media()
+	local player = Mpris.Player.new("spotify")
+
+	return Widget.Box({
+		css_classes = { "Media" },
+		visible = bind(player, "available"),
+		Widget.Image({
+			css_classes = { "Cover" },
+			valign = "CENTER",
+			file = bind(player, "cover-art"),
+		}),
+		Widget.Label({
+			label = bind(player, "metadata"):as(
+				function()
+					return (player.title or "")
+						.. " - "
+						.. (player.artist or "")
+				end
+			),
+		}),
+	})
+end
+
+local function Workspaces()
+	local hypr = Hyprland.get_default()
+
+	return Widget.Box({
+		css_classes = { "Workspaces" },
+		bind(hypr, "workspaces"):as(function(wss)
+			table.sort(wss, function(a, b) return a.id < b.id end)
+
+			return map(wss, function(ws)
+				if not (ws.id >= -99 and ws.id <= -2) then -- filter out special workspaces
+					return Widget.Button({
+						css_classes = bind(hypr, "focused-workspace"):as(
+							function(fw) return fw == ws and { "focused" } or {} end
+						),
+						on_clicked = function() ws:focus() end,
+						label = bind(ws, "id"):as(
+							function(v)
+								return type(v) == "number"
+										and string.format("%.0f", v)
+									or v
+							end
+						),
+					})
+				end
+			end)
+		end),
+	})
+end
+
+local function Time(format)
+	local time = Variable.new(""):poll(
+		1000,
+		function() return GLib.DateTime.new_now_local():format(format) end
+	)
+
+	return Widget.Label({
+		css_classes = { "Time" },
+		on_destroy = function() time:drop() end,
+		label = bind(time),
+	})
+end
+
+return function(gdkmonitor)
+	return Widget.Window({
+		css_classes = { "Bar" },
+		gdkmonitor = gdkmonitor,
+		anchor = { "TOP", "LEFT", "RIGHT" },
+		exclusivity = "EXCLUSIVE",
+		Widget.CenterBox({
+			Widget.Box({
+				halign = "START",
+				Workspaces(),
+				FocusedClient(),
+			}),
+			Widget.Box({
+				Media(),
+			}),
+			Widget.Box({
+				halign = "END",
+				SysTray(),
+				Wifi(),
+				AudioSlider(),
+				BatteryLevel(),
+				Time("%H:%M - %A %e."),
+			}),
+		}),
+	})
+end

--- a/examples/gtk4/stylua.toml
+++ b/examples/gtk4/stylua.toml
@@ -1,0 +1,4 @@
+indent_type = "Tabs"
+indent_width = 4
+column_width = 80
+collapse_simple_statement = "Always"


### PR DESCRIPTION
This pull request adds support for **GTK4**, along with a CLI to interact with running **astal-lua** instances:

```bash
astal-lua  # (requires argparse)
```

Also reimplements the classes/functions previously provided by **astal-io**:

* `read_file`, `write_file`, `monitor_file`
* `interval`, `timeout`, `idle`
* `process`, `subprocess`, `exec`
* `app`

Now, functions like `interval`, `timeout`, and `idle` return a function that can be used to cancel the `interval`/`timeout`/`idle` if needed.

You can use `App:add_request_handler()` to add additional request handlers for requests made with the CLI using `astal-lua request`, in addition to the `request_handler` defined in `App:start`.

**Example:**

```lua
App:start {
    request_handler = function(args, res)
        for _, arg in ipairs(args) do
            if arg == 'ping' then res('pong') end
        end
        res('invalid request')
    end
}
```

```lua
App:add_request_handler(function(args, res)
    for _, arg in ipairs(args) do
        if arg == 'hi' then res('helo') end
    end
end)
```
## New features

* **HTTP requests module** using [libsoup](https://libsoup.gnome.org/libsoup-3.0/index.html)
* async/await wrappers have also been added — see the [docs](https://github.com/tokyob0t/astal-lua/wiki/Async-Await).

